### PR TITLE
No TTY compatibility for monitor

### DIFF
--- a/lib/opsicle/monitor/app.rb
+++ b/lib/opsicle/monitor/app.rb
@@ -27,12 +27,12 @@ module Opsicle
         @threads       = {}
         @deployment_id = options[:deployment_id]
 
-        if @deployment_id.nil?
-          raise "Monitor requires a TTY." unless $stdout.tty?
-        else
-          # Make client with correct configuration available to monitor spies
-          App.client = Client.new(environment)
+        # Make client with correct configuration available to monitor spies
+        App.client = Client.new(environment)
+        if @deployment_id
           @deploy = Opsicle::Deployment.new(@deployment_id, App.client)
+        else
+          raise "Monitor requires a TTY." unless $stdout.tty?
         end
       end
 

--- a/lib/opsicle/monitor/app.rb
+++ b/lib/opsicle/monitor/app.rb
@@ -177,7 +177,7 @@ module Opsicle
 
       def check_deploy_status
         if deploy.running?
-          Output.say(". ") if $stdout.tty?
+          Output.say(". ") unless $stdout.tty?
         else
           if deploy.failed?
             stop(error: Opsicle::Errors::DeployFailed.new(deploy.command))

--- a/lib/opsicle/monitor/app.rb
+++ b/lib/opsicle/monitor/app.rb
@@ -30,7 +30,7 @@ module Opsicle
         # Make client with correct configuration available to monitor spies
         App.client = Client.new(environment)
         if @deployment_id
-          # `deploy` or `execute-recipes` command, which is no-tty compatible so these can be automated via cron, etc.
+          # `deploy`, `chef-update`, `execute-recipes` command, which is no-tty compatible so these can be automated via cron, etc.
           @deploy = Opsicle::Deployment.new(@deployment_id, App.client)
         else
           # `monitor` command, which requires a TTY.
@@ -75,7 +75,7 @@ module Opsicle
 
         @running = false
         wakey_wakey
-        @screen.close
+        @screen.close unless @screen.nil?
         @screen = nil # Ruby curses lib doesn't have closed?(), so we set to nil, just in case
 
         options[:error] ? raise(options[:error]) : raise(QuitMonitor, options[:message])
@@ -167,7 +167,7 @@ module Opsicle
       # to the spies would get ugly.
       def refresh_deploy_status_loop
         while @running do
-          next unless @screen # HACK: only certain test scenarios?
+          next unless @screen || !$stdout.tty?# HACK: only certain test scenarios?
 
           check_deploy_status
 

--- a/spec/opsicle/commands/update_spec.rb
+++ b/spec/opsicle/commands/update_spec.rb
@@ -49,7 +49,8 @@ module Opsicle
       it "should print changes with table" do
         allow(HashDiff).to receive(:diff) { [%w[- nyan 1], %w[+ cat 2],%w[~ taco 3 4]] }
         expect(Output).to receive(:say).with("Changes: 3") { nil }
-        expect(Output).to receive_message_chain("terminal.say")
+        allow(Output).to receive_message_chain("terminal.say")
+        allow(Output).to receive_message_chain("terminal.color")
         subject.print(nil, nil)
       end
     end

--- a/spec/opsicle/monitor/app_spec.rb
+++ b/spec/opsicle/monitor/app_spec.rb
@@ -32,7 +32,7 @@ describe Opsicle::Monitor::App do
 
     it "raises error without a tty" do
       expect($stdout).to receive(:tty?) { false }
-      expect(Opsicle::Monitor::App.new("staging", {})).to raise_error(RuntimeError, "Monitor requires a TTY.")
+      expect { Opsicle::Monitor::App.new("staging", {}) }.to raise_error(RuntimeError, "Monitor requires a TTY.")
     end
 
     context "when the app is montoring a deploy" do

--- a/spec/opsicle/monitor/app_spec.rb
+++ b/spec/opsicle/monitor/app_spec.rb
@@ -30,6 +30,11 @@ describe Opsicle::Monitor::App do
       expect(@app.restarting).to equal(false)
     end
 
+    it "raises error without a tty" do
+      expect($stdout).to receive(:tty?) { false }
+      expect(Opsicle::Monitor::App.new("staging", {})).to raise_error(RuntimeError, "Monitor requires a TTY.")
+    end
+
     context "when the app is montoring a deploy" do
       before do
         @app = Opsicle::Monitor::App.new("staging", {:deployment_id => 123})
@@ -41,6 +46,11 @@ describe Opsicle::Monitor::App do
 
       it "assigns a deploy" do
         expect(@app.deploy).to be_an_instance_of(Opsicle::Deployment)
+      end
+
+      it "works without a tty for a deployment" do
+        allow($stdout).to receive(:tty?) { false }
+        Opsicle::Monitor::App.new("staging", {:deployment_id => 123})
       end
     end
 


### PR DESCRIPTION
## Description
* Raise exception if monitor used without a TTY or a deployment.
* Make monitor work without a TTY for purposes of tracking a deployment and output to log/stdout instead.
* deploy and execute-recipe actions will now support execution from a non interactive script.

## QA
no tty: `bundle exec opsicle deploy -t staging | cat`
tty: `bundle exec opsicle deploy -t staging`