### PR TITLE
Drop support for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.0
   - 2.1
-  - 1.9.3
+  - 2.2
 script: bundle exec rspec
 matrix:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,3 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in opsicle.gemspec
 gemspec
 
-gem 'curses' if RUBY_VERSION >= '2.1' || RUBY_PLATFORM == 'java'
-

--- a/README.markdown
+++ b/README.markdown
@@ -7,28 +7,9 @@ A gem bringing the glory of OpsWorks to your command line.
 ## Installation
 Add this line to your project's Gemfile:
 
-**For Ruby >=2.1.0**
-
-```ruby
-gem 'opsicle'
-gem 'curses'
-```
-
-**For Ruby <2.1.0, 1.9.3**
-
 ```ruby
 gem 'opsicle'
 ```
-
-(Alternatively, `gem 'opsicle'; gem 'curses' unless RUBY_VERSION < "2.1.0"`)
-
-**Why the extra `curses` gem for Ruby 2.1.0+?**  
-Opsicle uses [curses](http://en.wikipedia.org/wiki/Curses_(programming_library)).
-Ruby's library to interface with curses was [removed from stdlib in Ruby 2.1.0](https://bugs.ruby-lang.org/issues/8584).
-[The new curses gem](https://github.com/ruby/curses) is not backwards compatible, so in an effort to keep this gem
-friendly with all current Ruby versions we don't list it as a dependency in Opsicle's gemspec - doing so would cause
-errors for Ruby 1.9.3 users.
-Ruby >=2.1.0 will likely be enforced sometime in 2014; [certainly by February 2015](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/).
 
 ### Set up an Application to use opsicle
 

--- a/opsicle.gemspec
+++ b/opsicle.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "terminal-table", "~> 1.4"
   spec.add_dependency "minitar", "~> 0.5"
   spec.add_dependency "hashdiff", "~> 0.2"
+  spec.add_dependency "curses", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1"


### PR DESCRIPTION
~~This completes the "Ruby >=2.1.0 will likely be enforced sometime in 2014; [certainly by February 2015" statement from the README.~~ Nope, this keeps Ruby 2.0 support, but with https://github.com/ruby/curses/pull/4 we still don't need to worry about Ruby version and whether to manually include `curses` in someone's Gemfile.

--------

Ruby 1.9 has been end-of-lifed. No need to worry about legacy with regards to `curses`.

* Clean up README explaining the whole `curses` thing.
* Remove a bit of code around ruby version
* Remove Ruby 1.9 from the build
* Add Ruby 2.2 to the build