### PR TITLE
Add option use private IPs for SSH when VPN is required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 2.0
   - 2.1

--- a/lib/opsicle/commands/ssh.rb
+++ b/lib/opsicle/commands/ssh.rb
@@ -43,18 +43,23 @@ module Opsicle
       @user_profile.ssh_username
     end
 
+    def ssh_ip(instance)
+      if client.config.opsworks_config[:internal_ssh_only]
+        Output.say "This stack requires a private connection, only using internal IPs."
+        instance[:private_ip]
+      else
+        instance[:elastic_ip] || instance[:public_ip]
+      end
+    end
+
     def ssh_command(instance, options={})
       ssh_command = " \"#{options[:"ssh-cmd"].gsub(/'/){ %q(\') }}\"" if options[:"ssh-cmd"] #escape single quotes
       ssh_options = options[:"ssh-opts"] ? "#{options[:"ssh-opts"]} " : ""
-      if client.config.opsworks_config[:vpn_required]
-        ssh_string = "#{ssh_username}@#{instance[:private_ip]}"
+      if instance_ip = ssh_ip(instance)
+        ssh_string = "#{ssh_username}@#{instance_ip}"
       else
-        if instance_ip = instance[:elastic_ip] || instance[:public_ip]
-          ssh_string = "#{ssh_username}@#{instance_ip}"
-        else
-          ssh_string = "#{ssh_username}@#{public_ips.sample} ssh #{instance[:private_ip]}"
-          ssh_options.concat('-A -t ')
-        end
+        ssh_string = "#{ssh_username}@#{public_ips.sample} ssh #{instance[:private_ip]}"
+        ssh_options.concat('-A -t ')
       end
 
       "ssh #{ssh_options}#{ssh_string}#{ssh_command}"

--- a/lib/opsicle/commands/ssh.rb
+++ b/lib/opsicle/commands/ssh.rb
@@ -46,11 +46,15 @@ module Opsicle
     def ssh_command(instance, options={})
       ssh_command = " \"#{options[:"ssh-cmd"].gsub(/'/){ %q(\') }}\"" if options[:"ssh-cmd"] #escape single quotes
       ssh_options = options[:"ssh-opts"] ? "#{options[:"ssh-opts"]} " : ""
-      if instance_ip = instance[:elastic_ip] || instance[:public_ip]
-        ssh_string = "#{ssh_username}@#{instance_ip}"
+      if client.config.opsworks_config[:vpn_required]
+        ssh_string = "#{ssh_username}@#{instance[:private_ip]}"
       else
-        ssh_string = "#{ssh_username}@#{public_ips.sample} ssh #{instance[:private_ip]}"
-        ssh_options.concat('-A -t ')
+        if instance_ip = instance[:elastic_ip] || instance[:public_ip]
+          ssh_string = "#{ssh_username}@#{instance_ip}"
+        else
+          ssh_string = "#{ssh_username}@#{public_ips.sample} ssh #{instance[:private_ip]}"
+          ssh_options.concat('-A -t ')
+        end
       end
 
       "ssh #{ssh_options}#{ssh_string}#{ssh_command}"

--- a/spec/opsicle/commands/ssh_spec.rb
+++ b/spec/opsicle/commands/ssh_spec.rb
@@ -72,13 +72,25 @@ module Opsicle
         subject.execute({ :"ssh-opts" => '-p 234', :"ssh-cmd" => 'cd /srv/www'})
       end
 
-      it "executes sshs through an instance with a public_ip to get to one with a private_ip" do
+      it "executes ssh through an instance with a public_ip to get to one with a private_ip" do
         allow(subject).to receive(:instances) {[
                             { hostname: "host1", elastic_ip: "123.123.123.123" },
                             { hostname: "host2", private_ip: "789.789.789.789" }
                           ]}
         expect(subject).to receive(:system).with("ssh -A -t mrderpyman2014@123.123.123.123 ssh 789.789.789.789")
         subject.execute
+      end
+
+      context "when internal_ssh_only is enabled" do
+        let(:client) { double(config: double(opsworks_config: {stack_id: "1234", internal_ssh_only: true})) }
+        it "ssh to a private_ip " do
+          allow(subject).to receive(:instances) {[
+                              { hostname: "host1", elastic_ip: "123.123.123.123", private_ip: "10.10.10.10"}
+                            ]}
+          expect(subject).to receive(:system).with("ssh mrderpyman2014@10.10.10.10")
+          expect(Output).to receive(:say).with("This stack requires a private connection, only using internal IPs.")
+          subject.execute
+        end
       end
     end
 
@@ -108,6 +120,26 @@ module Opsicle
       it "makes a describe_my_user_profile API call" do
         allow(user_profile).to receive(:ssh_username).and_return("captkirk01")
         expect(subject.ssh_username).to eq("captkirk01")
+      end
+    end
+
+    context "#ssh_ip" do
+      let(:instance) { { hostname: "host1", elastic_ip: "123.123.123.123", public_ip: "123.345.567.789", private_ip: "10.10.10.10" } }
+      context "when internal_ssh_only is enabled" do
+        let(:client) { double(config: double(opsworks_config: {stack_id: "1234", internal_ssh_only: true})) }
+        it "returns an internal IP" do
+          expect(Output).to receive(:say).with("This stack requires a private connection, only using internal IPs.")
+          expect(subject.ssh_ip(instance)).to eq("10.10.10.10")
+        end
+      end
+      context "when internal_ssh_only is not enabled" do
+        it "returns elastic IP if it is present" do
+          expect(subject.ssh_ip(instance)).to eq("123.123.123.123")
+        end
+        it "returns a public IP if there is no elastic ip" do
+          instance.delete(:elastic_ip)
+          expect(subject.ssh_ip(instance)).to eq("123.345.567.789")
+        end
       end
     end
 


### PR DESCRIPTION
Description and Impact
----------------------
Add the following line to an environment config to force opsicle to use private IPs
```
vpn_required: true
```
Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
Add `vpn_required: true` to a stack config and make sure opsicle tries to connect to private IPs using the SSH command.
