### PR TITLE
Fix Deploy Regression

### DIFF
--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -27,8 +27,15 @@ module Opsicle
       "https://console.aws.amazon.com/opsworks/home?#/stack/#{@config.opsworks_config[:stack_id]}"
     end
 
+    def stack_config
+      {
+        stack_id: config.opsworks_config[:stack_id],
+        app_id: config.opsworks_config[:app_id]
+      }
+    end
+
     def command_options(command, command_args={}, options={})
-      config.opsworks_config.merge(options).merge({ command: { name: command, args: command_args } })
+      stack_config.merge(options).merge({ command: { name: command, args: command_args } })
     end
     private :command_options
 

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -8,7 +8,7 @@ module Opsicle
     let(:config) { double }
     before do
       ow_stub = double
-      allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app' })
+      allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app', something_else: 'true' })
       allow(ow_stub).to receive(:client).and_return(aws_client)
       allow(Config).to receive(:new).and_return(config)
       allow(AWS::OpsWorks).to receive(:new).and_return(ow_stub)
@@ -24,6 +24,11 @@ module Opsicle
             app_id: 'app'
           )
         )
+        subject.run_command('deploy')
+      end
+      it "removes extra options from the opsworks config" do
+        expect(config).to receive(:configure_aws!)
+        expect(aws_client).to receive(:create_deployment).with(hash_excluding(:something_else))
         subject.run_command('deploy')
       end
     end


### PR DESCRIPTION
Description and Impact
----------------------
Fixes a regression that sent extra options from `.opsicle` config to the Opsworkls API and adds tests to verify.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.
