### PR TITLE
Upgrading aws-sdk to v2 from v1

### DIFF
--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -10,7 +10,7 @@ module Opsicle
       @config = Config.instance
       @config.configure_aws_environment!(environment)
       @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
-      @s3 = Aws::S3::Client.new(region: 'us-east-1')
+      @s3 = Aws::S3::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
     end
 
     def run_command(command, command_args={}, options={})

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -9,8 +9,8 @@ module Opsicle
     def initialize(environment)
       @config = Config.new(environment)
       @config.configure_aws!
-      @opsworks = Aws::OpsWorks::Client.new
-      @s3 = Aws::S3::Client.new
+      @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config)
+      @s3 = Aws::S3::Client.new(region: 'us-east-1')
     end
 
     def run_command(command, command_args={}, options={})

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -9,8 +9,8 @@ module Opsicle
     def initialize(environment)
       @config = Config.new(environment)
       @config.configure_aws!
-      @opsworks = AWS::OpsWorks.new.client
-      @s3 = AWS::S3.new
+      @opsworks = Aws::OpsWorks::Client.new
+      @s3 = Aws::S3::Client.new
     end
 
     def run_command(command, command_args={}, options={})

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -8,7 +8,6 @@ module Opsicle
 
     def initialize(environment)
       @config = Config.new(environment)
-      @config.configure_aws!
       @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
       @s3 = Aws::S3::Client.new(region: 'us-east-1')
     end

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -9,7 +9,7 @@ module Opsicle
     def initialize(environment)
       @config = Config.new(environment)
       @config.configure_aws!
-      @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config)
+      @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
       @s3 = Aws::S3::Client.new(region: 'us-east-1')
     end
 
@@ -20,7 +20,7 @@ module Opsicle
     end
 
     def api_call(command, options={})
-      opsworks.public_send(command, options)
+      opsworks.public_send(command, options).to_h
     end
 
     def opsworks_url

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -8,7 +8,7 @@ module Opsicle
 
     def initialize(environment)
       @config = Config.instance
-      @config.configure_aws!(environment)
+      @config.configure_aws_environment!(environment)
       @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
       @s3 = Aws::S3::Client.new(region: 'us-east-1')
     end

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -7,7 +7,8 @@ module Opsicle
     attr_reader :config
 
     def initialize(environment)
-      @config = Config.new(environment)
+      @config = Config.instance
+      @config.configure_aws!(environment)
       @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
       @s3 = Aws::S3::Client.new(region: 'us-east-1')
     end

--- a/lib/opsicle/commands/ssh.rb
+++ b/lib/opsicle/commands/ssh.rb
@@ -29,8 +29,7 @@ module Opsicle
     end
 
     def instances
-      @instances ||= client.api_call(:describe_instances, { stack_id: client.config.opsworks_config[:stack_id] })
-                           .data[:instances]
+      @instances ||= client.api_call(:describe_instances, { stack_id: client.config.opsworks_config[:stack_id] })[:instances]
                            .select { |instance| instance[:status].to_s == 'online'}
                            .sort { |a,b| a[:hostname] <=> b[:hostname] }
     end

--- a/lib/opsicle/commands/ssh_clean_keys.rb
+++ b/lib/opsicle/commands/ssh_clean_keys.rb
@@ -22,8 +22,7 @@ module Opsicle
     end
 
     def instances
-      client.api_call(:describe_instances, { stack_id: client.config.opsworks_config[:stack_id] })
-        .data[:instances]
+      client.api_call(:describe_instances, { stack_id: client.config.opsworks_config[:stack_id] })[:instances]
     end
   end
 end

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -35,11 +35,6 @@ module Opsicle
       @opsworks_config ||= load_config(OPSICLE_CONFIG_PATH)
     end
 
-    # def configure_aws!
-    #   # we want this to now be a vanilla ruby hash, not a method
-    #   Aws.config[:credentials] = @aws_config
-    # end
-
     def load_config(file)
       raise MissingConfig, "Missing configuration file: #{file}  Run 'opsicle help'" unless File.exist?(file)
       env_config = symbolize_keys(YAML.load_file(file))[environment] rescue {}

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -63,7 +63,9 @@ module Opsicle
                                  region: 'us-east-1')
       role_arn = fog_config[:mfa_serial_number]
       role_arn = role_arn.scan(/(arn:aws:iam::[\d]+:)/).flatten.first
-      role_arn << "role/"
+      role_arn << "role/sportnginuser" # do we actually need to create a role here?
+      # will we need to call this with different credentials to valid when trying to make a session
+      # is `assume_role` even the method we should be using to replace new_session
       @session = sts.assume_role(role_arn: role_arn,
                                  role_session_name: "RoleSession1",
                                  duration_seconds: session_duration,

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -13,6 +13,10 @@ module Opsicle
       @environment = environment.to_sym
     end
 
+    def aws_credentials
+      Aws::Credentials.new(aws_config[:access_key_id], aws_config[:secret_access_key])
+    end
+
     def aws_config
       return @aws_config if @aws_config
       if fog_config[:mfa_serial_number]

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -36,7 +36,7 @@ module Opsicle
       @opsworks_config ||= load_config(OPSICLE_CONFIG_PATH)
     end
 
-    def configure_aws!(environment)
+    def configure_aws_environment!(environment)
       return if environment == @environment
       @environment = environment.to_sym
       end

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -37,7 +37,6 @@ module Opsicle
     end
 
     def configure_aws_environment!(environment)
-      return if environment == @environment
       @environment = environment.to_sym
       end
 

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -9,8 +9,8 @@ module Opsicle
 
     attr_reader :environment
 
-    def initialize(environment)
-      @environment = environment.to_sym
+    def self.instance
+      @instance ||= new
     end
 
     def aws_credentials
@@ -35,7 +35,7 @@ module Opsicle
     def opsworks_config
       @opsworks_config ||= load_config(OPSICLE_CONFIG_PATH)
     end
-    
+
     def configure_aws!(environment)
       return if environment == @environment
       @environment = environment.to_sym

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -35,10 +35,10 @@ module Opsicle
       @opsworks_config ||= load_config(OPSICLE_CONFIG_PATH)
     end
 
-    def configure_aws!
-      # we want this to now be a vanilla ruby hash, not a method
-      Aws.config[:credentials] = @aws_config
-    end
+    # def configure_aws!
+    #   # we want this to now be a vanilla ruby hash, not a method
+    #   Aws.config[:credentials] = @aws_config
+    # end
 
     def load_config(file)
       raise MissingConfig, "Missing configuration file: #{file}  Run 'opsicle help'" unless File.exist?(file)

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -32,7 +32,8 @@ module Opsicle
     end
 
     def configure_aws!
-      AWS.config(aws_config)
+      # we want this to now be a vanilla ruby hash, not a method
+      Aws.config[:credentials] = @aws_config
     end
 
     def load_config(file)
@@ -49,8 +50,9 @@ module Opsicle
 
     def get_session
       return @session if @session
-      sts = AWS::STS.new(access_key_id: fog_config[:aws_access_key_id],
-                           secret_access_key: fog_config[:aws_secret_access_key])
+      credentials = {access_key_id: fog_config[:aws_access_key_id],
+                     secret_access_key: fog_config[:aws_secret_access_key]}
+      sts = Aws::STS::Client.new(credentials: credentials, region: 'us-east-1')
       @session = sts.new_session(duration: session_duration, serial_number: fog_config[:mfa_serial_number],
                                  token_code: get_mfa_token)
     end

--- a/lib/opsicle/instances.rb
+++ b/lib/opsicle/instances.rb
@@ -2,7 +2,7 @@ module Opsicle
   class Instances
 
     attr_accessor :client
-    class <<self
+    class << self
       attr_accessor :client
     end
 

--- a/opsicle.gemspec
+++ b/opsicle.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['spec/**/*']
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 1.30"
+  spec.add_dependency "aws-sdk", "~> 2"
   spec.add_dependency "gli", "~> 2.9"
   spec.add_dependency "highline", "~> 1.6"
   spec.add_dependency "terminal-table", "~> 1.4"

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -14,10 +14,10 @@ module Opsicle
       allow(Config).to receive(:instance).and_return(config)
       allow(Aws::OpsWorks::Client).to receive(:new).and_return(aws_client)
       allow(Aws::S3::Client).to receive(:new).and_return(aws_client)
-      allow(config).to receive(:configure_aws!).with("derp")
-      allow(aws_client).to receive(:configure_aws!).with("derp")
-      allow(subject).to receive(:configure_aws!).with("derp")
-      allow(Client).to receive(:configure_aws!).with("derp")
+      allow(config).to receive(:configure_aws_environment!).with("derp")
+      allow(aws_client).to receive(:configure_aws_environment!).with("derp")
+      allow(subject).to receive(:configure_aws_environment!).with("derp")
+      allow(Client).to receive(:configure_aws_environment!).with("derp")
     end
 
     context "#run_command" do

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -7,6 +7,8 @@ module Opsicle
     let(:aws_client) { double }
     let(:config) { double }
     before do
+      mock_keys = {access_key_id: 'key', secret_access_key: 'secret'}
+      allow(config).to receive(:aws_credentials).and_return(mock_keys)
       allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app', something_else: 'true' })
       allow(Config).to receive(:new).and_return(config)
       allow(Aws::OpsWorks::Client).to receive(:new).and_return(aws_client)

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -11,8 +11,16 @@ module Opsicle
       allow(config).to receive(:aws_credentials).and_return(mock_keys)
       allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app', something_else: 'true' })
       allow(Config).to receive(:new).and_return(config)
+      allow(Config).to receive(:instance).and_return(config)
       allow(Aws::OpsWorks::Client).to receive(:new).and_return(aws_client)
       allow(Aws::S3::Client).to receive(:new).and_return(aws_client)
+      allow(subject).to receive(:configure_aws!).with('derp')
+    end
+    before :each do
+      allow(config).to receive(:configure_aws!).with("derp")
+      allow(aws_client).to receive(:configure_aws!).with("derp")
+      allow(subject).to receive(:configure_aws!).with("derp")
+      allow(Client).to receive(:configure_aws!).with("derp")
     end
 
     context "#run_command" do

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -11,7 +11,8 @@ module Opsicle
       allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app', something_else: 'true' })
       allow(ow_stub).to receive(:client).and_return(aws_client)
       allow(Config).to receive(:new).and_return(config)
-      allow(Aws::OpsWorks).to receive(:new).and_return(ow_stub)
+      allow(Aws::OpsWorks::Client).to receive(:new).and_return(ow_stub)
+      allow(Aws::S3::Client).to receive(:new).and_return(ow_stub)
     end
 
     context "#run_command" do

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -17,7 +17,6 @@ module Opsicle
 
     context "#run_command" do
       it "calls out to the aws client with all the config options" do
-        expect(config).to receive(:configure_aws!)
         expect(aws_client).to receive(:create_deployment).with(
           hash_including(
             command: { name: 'deploy', args: {} },
@@ -28,7 +27,6 @@ module Opsicle
         subject.run_command('deploy')
       end
       it "removes extra options from the opsworks config" do
-        expect(config).to receive(:configure_aws!)
         expect(aws_client).to receive(:create_deployment).with(hash_excluding(:something_else))
         subject.run_command('deploy')
       end

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -11,7 +11,7 @@ module Opsicle
       allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app', something_else: 'true' })
       allow(ow_stub).to receive(:client).and_return(aws_client)
       allow(Config).to receive(:new).and_return(config)
-      allow(AWS::OpsWorks).to receive(:new).and_return(ow_stub)
+      allow(Aws::OpsWorks).to receive(:new).and_return(ow_stub)
     end
 
     context "#run_command" do

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -7,12 +7,10 @@ module Opsicle
     let(:aws_client) { double }
     let(:config) { double }
     before do
-      ow_stub = double
       allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app', something_else: 'true' })
-      allow(ow_stub).to receive(:client).and_return(aws_client)
       allow(Config).to receive(:new).and_return(config)
-      allow(Aws::OpsWorks::Client).to receive(:new).and_return(ow_stub)
-      allow(Aws::S3::Client).to receive(:new).and_return(ow_stub)
+      allow(Aws::OpsWorks::Client).to receive(:new).and_return(aws_client)
+      allow(Aws::S3::Client).to receive(:new).and_return(aws_client)
     end
 
     context "#run_command" do

--- a/spec/opsicle/commands/ssh_spec.rb
+++ b/spec/opsicle/commands/ssh_spec.rb
@@ -7,7 +7,6 @@ module Opsicle
     let(:client) { double(config: double(opsworks_config: {stack_id: "1234"})) }
     let(:stack) { double(client: client) }
     let(:user_profile) { double }
-    let(:api_call) { double }
     before do
       allow(Client).to receive(:new).with('derp').and_return(client)
       allow(Stack).to receive(:new).with(client).and_return(stack)
@@ -104,14 +103,12 @@ module Opsicle
     context "#instances" do
       it "makes a describe_instances API call" do
         expect(client).to receive(:api_call).with(:describe_instances, {stack_id: "1234"})
-          .and_return(api_call)
-        expect(api_call).to receive(:data).and_return(instances: [{:name => :foo, :status => "online"},{:name => :bar, :status => "stopped"}])
+          .and_return(instances: [{:name => :foo, :status => "online"},{:name => :bar, :status => "stopped"}])
         expect(subject.instances).to eq([{:name => :foo, :status=>"online"}])
       end
       it "sorts instances by hostname" do
         expect(client).to receive(:api_call).with(:describe_instances, {stack_id: "1234"})
-          .and_return(api_call)
-        expect(api_call).to receive(:data).and_return(instances: [{:hostname => "taco", :status => "online"},{:hostname => "bar", :status => "online"}])
+          .and_return(instances: [{:hostname => "taco", :status => "online"},{:hostname => "bar", :status => "online"}])
         expect(subject.instances).to eq([{:hostname => "bar", :status=>"online"}, {:hostname => "taco", :status=>"online"}])
       end
     end

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -12,7 +12,7 @@ module Opsicle
         allow(YAML).to receive(:load_file).with('./.opsicle').and_return({'derp' => { 'app_id' => 'app', 'stack_id' => 'stack'}})
       end
       before :each do
-        subject.configure_aws!('derp')
+        subject.configure_aws_environment!('derp')
       end
 
       context "#aws_config" do
@@ -45,9 +45,9 @@ module Opsicle
         end
       end
 
-      context "#configure_aws!" do
-        it "should return aws credentials" do
-          expect(subject.configure_aws!("environment")).to eq(:environment)
+      context "#configure_aws_environment!" do
+        it "should return the environment as a symbol" do
+          expect(subject.configure_aws_environment!("environment")).to eq(:environment)
         end
       end
     end

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -3,13 +3,16 @@ require "opsicle"
 
 module Opsicle
   describe Config do
-    subject { Config.new('derp') }
+    subject { Config.new }
     context "with a valid config" do
       before do
         allow(File).to receive(:exist?).with(File.expand_path '~/.fog').and_return(true)
         allow(File).to receive(:exist?).with('./.opsicle').and_return(true)
         allow(YAML).to receive(:load_file).with(File.expand_path '~/.fog').and_return({'derp' => { 'aws_access_key_id' => 'key', 'aws_secret_access_key' => 'secret'}})
         allow(YAML).to receive(:load_file).with('./.opsicle').and_return({'derp' => { 'app_id' => 'app', 'stack_id' => 'stack'}})
+      end
+      before :each do
+        subject.configure_aws!('derp')
       end
 
       context "#aws_config" do
@@ -41,13 +44,6 @@ module Opsicle
           expect(subject.aws_credentials).to eq(credentials)
         end
       end
-
-      context "#configure_aws!" do
-        it "should load the config into the AWS module" do
-          expect(subject.configure_aws!("derp")).to eq(:derp)
-          subject.configure_aws!("derp")
-        end
-      end
     end
 
     context "missing configs" do
@@ -72,6 +68,12 @@ module Opsicle
         it "should gracefully raise an exception if no .fog file was found" do
           expect {subject.opsworks_config}.to raise_exception(Config::MissingConfig)
         end
+      end
+    end
+
+    context "singleton support" do
+      it "should return a single instance" do
+        expect(Config.instance).to eq(Config.instance)
       end
     end
   end

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -71,10 +71,10 @@ module Opsicle
       end
     end
 
-    # context "singleton support" do
-    #   it "should return a single instance" do
-    #     expect(Config.instance).to eq(Config.instance)
-    #   end
-    # end
+    context "singleton support" do
+      it "should return a single instance" do
+        expect(Config.instance).to eq(Config.instance)
+      end
+    end
   end
 end

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -71,10 +71,10 @@ module Opsicle
       end
     end
 
-    context "singleton support" do
-      it "should return a single instance" do
-        expect(Config.instance).to eq(Config.instance)
-      end
-    end
+    # context "singleton support" do
+    #   it "should return a single instance" do
+    #     expect(Config.instance).to eq(Config.instance)
+    #   end
+    # end
   end
 end

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -34,7 +34,7 @@ module Opsicle
 
       context "#configure_aws!" do
         it "should load the config into the AWS module" do
-          expect(AWS).to receive(:config).with(hash_including(access_key_id: 'key', secret_access_key: 'secret'))
+          expect(subject.aws_config).to include(access_key_id: 'key', secret_access_key: 'secret')
           subject.configure_aws!
         end
       end
@@ -52,14 +52,13 @@ module Opsicle
         mock_credentials = { access_key_id: 'key', secret_access_key: 'secret', session_token: 'cats' }
         allow(mock_session).to receive(:credentials).and_return(mock_credentials)
         allow(mock_sts).to receive(:new_session).and_return(mock_session)
-        allow(AWS::STS).to receive(:new).and_return(mock_sts)
+        allow(Aws::STS).to receive(:new).and_return(mock_sts)
         allow(Output).to receive(:ask).and_return(123456)
       end
 
       context "#configure_aws!" do
         it "should load the config into the AWS module" do
-          expect(AWS).to receive(:config).with(hash_including(access_key_id: 'key', secret_access_key: 'secret',
-                                               session_token: 'cats'))
+          expect(subject.aws_config).to include(access_key_id: 'key', secret_access_key: 'secret', session_token: 'cats')
           subject.configure_aws!
         end
       end

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -33,6 +33,14 @@ module Opsicle
           expect(subject.opsworks_config).to have_key(:app_id)
         end
       end
+
+      context "#aws_credentials" do
+        it "should return aws credentials" do
+          credentials = double
+          allow(Aws::Credentials).to receive(:new).and_return(credentials)
+          expect(subject.aws_credentials).to eq(credentials)
+        end
+      end
     end
 
     context "missing configs" do

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -31,39 +31,6 @@ module Opsicle
           expect(subject.opsworks_config).to have_key(:app_id)
         end
       end
-
-      context "#configure_aws!" do
-        it "should load the config into the AWS module" do
-          expect(subject.aws_config).to include(access_key_id: 'key', secret_access_key: 'secret')
-          subject.configure_aws!
-        end
-      end
-    end
-
-    context "with a valid MFA config" do
-      before do
-        allow(File).to receive(:exist?).with(File.expand_path '~/.fog').and_return(true)
-        allow(File).to receive(:exist?).and_call_original
-        mock_fog = { 'derp' => { 'aws_access_key_id' => 'key', 'aws_secret_access_key' => 'secret',
-                     'mfa_serial_number' => 'tacos' }}
-        allow(YAML).to receive(:load_file).with(File.expand_path '~/.fog').and_return(mock_fog)
-
-        mock_sts = Class.new
-        mock_session = Class.new
-        mock_keys = {access_key_id: 'key', secret_access_key: 'secret'}
-        mock_credentials = {session_token: 'cats'}.merge(mock_keys)
-        allow(mock_session).to receive(:credentials).and_return(mock_credentials)
-        allow(mock_sts).to receive(:new_session).and_return(mock_session)
-        allow(Aws::STS::Client).to receive(:new).with(credentials: mock_keys, region: 'us-east-1').and_return(mock_sts)
-        allow(Output).to receive(:ask).and_return(123456)
-      end
-
-      context "#configure_aws!" do
-        it "should load the config into the AWS module" do
-          expect(subject.aws_config).to include(access_key_id: 'key', secret_access_key: 'secret', session_token: 'cats')
-          subject.configure_aws!
-        end
-      end
     end
 
     context "missing configs" do

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -15,10 +15,12 @@ module Opsicle
       context "#aws_config" do
         it "should contain access_key_id" do
           expect(subject.aws_config).to have_key(:access_key_id)
+          expect(subject.aws_config).to eq({ :access_key_id => 'key', :secret_access_key => 'secret'})
         end
 
         it "should contain secret_access_key" do
           expect(subject.aws_config).to have_key(:secret_access_key)
+          expect(subject.aws_config).to eq({ :access_key_id => 'key', :secret_access_key => 'secret'})
         end
       end
 

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -44,6 +44,12 @@ module Opsicle
           expect(subject.aws_credentials).to eq(credentials)
         end
       end
+
+      context "#configure_aws!" do
+        it "should return aws credentials" do
+          expect(subject.configure_aws!("environment")).to eq(:environment)
+        end
+      end
     end
 
     context "missing configs" do

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -43,16 +43,18 @@ module Opsicle
     context "with a valid MFA config" do
       before do
         allow(File).to receive(:exist?).with(File.expand_path '~/.fog').and_return(true)
+        allow(File).to receive(:exist?).and_call_original
         mock_fog = { 'derp' => { 'aws_access_key_id' => 'key', 'aws_secret_access_key' => 'secret',
                      'mfa_serial_number' => 'tacos' }}
         allow(YAML).to receive(:load_file).with(File.expand_path '~/.fog').and_return(mock_fog)
 
         mock_sts = Class.new
         mock_session = Class.new
-        mock_credentials = { access_key_id: 'key', secret_access_key: 'secret', session_token: 'cats' }
+        mock_keys = {access_key_id: 'key', secret_access_key: 'secret'}
+        mock_credentials = {session_token: 'cats'}.merge(mock_keys)
         allow(mock_session).to receive(:credentials).and_return(mock_credentials)
         allow(mock_sts).to receive(:new_session).and_return(mock_session)
-        allow(Aws::STS).to receive(:new).and_return(mock_sts)
+        allow(Aws::STS::Client).to receive(:new).with(credentials: mock_keys, region: 'us-east-1').and_return(mock_sts)
         allow(Output).to receive(:ask).and_return(123456)
       end
 


### PR DESCRIPTION
Description and Impact
----------------------
Will close #89 when merged. Should not have any visible impact, but will be setting up for using the `~/.aws/credentials` instead of the `~/.fog` file. All functionality should work as normal. Also, merges #83 into here.

Deploy Plan
-----------
Unknown, but should probably make new release and put on RubyGems.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
[AWS Credentials](http://docs.aws.amazon.com/sdkforruby/api/Aws/Credentials.html)
[AWS EC2 Client](http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html)
[AWS-SDK Version 2](http://docs.aws.amazon.com/sdkforruby/api/)

QA Plan
-------
* need .opsicle file in directory for this to work
* all of the below commands will still be using the ~/.fog file
- [ ] Check that all commands continue to work as normal **without** MFA (ex: `bundle exec bin/opsicle --debug monitor staging`)
- [ ] Check that commands work when using environment **with** MFA (ex: `bundle exec bin/opsicle --debug monitor staging`)
- [ ] Make sure that commands work when there are two commands in a row used (ex `bundle exec bin/opsicle --debug deploy staging`)
- [ ] Try some other commands for regression purposes (run `bundle exec bin/opsicle` to see a list of commands)
