### PR TITLE
Fix bug that prevents users from updating chef cookbooks on aws-sdk v2

### DIFF
--- a/lib/opsicle/s3_bucket.rb
+++ b/lib/opsicle/s3_bucket.rb
@@ -2,17 +2,17 @@ require 'pathname'
 
 module Opsicle
   class S3Bucket
-     attr_reader :bucket
+    attr_reader :bucket
 
-     def initialize(client, bucket_name)
-        @bucket = Aws::S3::Bucket.new(name: bucket_name, client: client.s3)
-        raise UnknownBucket unless @bucket.exists?
-     end
+    def initialize(client, bucket_name)
+      @bucket = Aws::S3::Bucket.new(name: bucket_name, client: client.s3)
+      raise UnknownBucket unless @bucket.exists?
+    end
 
-     def update(object)
+    def update(object)
       obj = bucket.object(object)
       obj.upload_file(Pathname.new(object))
-     end
+    end
   end
 
   UnknownBucket = Class.new(StandardError)

--- a/lib/opsicle/s3_bucket.rb
+++ b/lib/opsicle/s3_bucket.rb
@@ -5,13 +5,13 @@ module Opsicle
      attr_reader :bucket
 
      def initialize(client, bucket_name)
-        @bucket = client.s3.buckets[bucket_name]
+        @bucket = Aws::S3::Bucket.new(name: bucket_name, client: client.s3)
         raise UnknownBucket unless @bucket.exists?
      end
 
      def update(object)
-       obj = bucket.objects[object]
-       obj.write(Pathname.new(object))
+      obj = bucket.object(object)
+      obj.upload_file(Pathname.new(object))
      end
   end
 

--- a/spec/opsicle/s3_bucket_spec.rb
+++ b/spec/opsicle/s3_bucket_spec.rb
@@ -3,48 +3,42 @@ require "opsicle"
 
 module Opsicle
   describe  S3Bucket do
-    subject { S3Bucket.new(client, bucket_name) }
-    let(:bucket_name) { "bucket" }
-    let(:bucket) { double(exists?: true) }
-    let(:buckets) { double(:"[]" => bucket) }
-    let(:s3) { double(buckets: buckets) }
-    let(:client) { double(s3: s3) }
+    before do
+      @object = double('object', :upload_file => true)
+      @bucket = double('bucket', :exists? => true, :object => @object)
+      allow(Aws::S3::Bucket).to receive(:new).and_return(@bucket)
+      @bucket_name = 'name'
+      @client = double('client', :s3 => true)
+      allow(Pathname).to receive(:new)
+    end
 
     context "#new" do
-      subject { S3Bucket }
-      it "finds the bucket from s3" do
-        expect(client).to receive(:s3).and_return(s3)
-        expect(s3).to receive(:buckets).and_return(buckets)
-        expect(buckets).to receive(:"[]").with(bucket_name).and_return(bucket)
-        subject.new(client, bucket_name)
+      it "find the bucket from s3" do
+        expect(@client).to receive(:s3)
+        expect(@bucket).to receive(:exists?)
+        expect(Aws::S3::Bucket).to receive(:new)
+        S3Bucket.new(@client, @bucket_name)
       end
 
       it "throws an error if the bucket can't be found" do
-        allow(bucket).to receive(:exists?).and_return(false)
-        expect(client).to receive(:s3).and_return(s3)
-        expect(s3).to receive(:buckets).and_return(buckets)
-        expect(buckets).to receive(:"[]").with(bucket_name).and_return(bucket)
-        expect { subject.new(client, bucket_name) }.to raise_error(UnknownBucket)
+        allow(@bucket).to receive(:exists?).and_return(false)
+        expect { S3Bucket.new(@client, @bucket_name) }.to raise_error(UnknownBucket)
       end
     end
 
     context "#update" do
-      let(:object) { double }
-      let(:objects) { double(:"[]" => object) }
-      before do
-        allow(Pathname).to receive(:new)
-      end
-
       it "finds the object in the s3 bucket" do
-        allow(object).to receive(:write)
-        expect(bucket).to receive(:objects).and_return(objects)
-        subject.update(object)
+        expect(@bucket).to receive(:object)
+        bucket = S3Bucket.new(@client, @bucket_name)
+        bucket.update("object")
       end
 
       it "writes the new object in the s3 bucket" do
-        allow(bucket).to receive(:objects).and_return(objects)
-        expect(object).to receive(:write)
-        subject.update(object)
+        expect(Pathname).to receive(:new).with("object")
+        expect(@object).to receive(:upload_file)
+        allow(@bucket).to receive(:object).and_return(@object)
+        bucket = S3Bucket.new(@client, @bucket_name)
+        bucket.update("object")
       end
     end
   end


### PR DESCRIPTION
Description and Impact
----------------------
Fix bug that prevents users from updating their chef cookbooks on aws-sdk v2. This will close https://github.com/sportngin/opsicle/issues/96.

Deploy Plan
-----------
* checkout master
* `op accept-pull 98`
* `soyuz deploy` and pick RubyGems with a patch release

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html
http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Bucket.html
http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html

QA Plan
-------
- [x] Run `bundle exec bin/opsicle chef-update [environment] -t --bucket-name [bucket name]` and watch the entire cookbooks update (there should be no error)