### PR TITLE
Fix bug with failure-log command

### DIFF
--- a/lib/opsicle/commands/failure_log.rb
+++ b/lib/opsicle/commands/failure_log.rb
@@ -21,13 +21,17 @@ module Opsicle
         failed_deployment_id = failed_deployments.first.deployment_id
         failed_deployments_instances = failed_deployments.first.instance_ids
 
-        involved_instance_id = fetch_instance_id(failed_deployments_instances)
+        unless failed_deployments_instances.empty?
+          involved_instance_id = fetch_instance_id(failed_deployments_instances)
 
-        target_failed_command = fetch_target_command(involved_instance_id, failed_deployment_id)
-        log_url = target_failed_command.first.log_url
+          target_failed_command = fetch_target_command(involved_instance_id, failed_deployment_id)
+          log_url = target_failed_command.first.log_url
         
-        system("open", log_url) if log_url
-        puts "Unable to find a url to open." unless log_url
+          system("open", log_url) if log_url
+          puts "Unable to find a url to open." unless log_url
+        else
+          puts "There are either no failed deployments in available history or there are no available logs for failures."
+        end
       else
         puts "No failed deployments in available history."
       end

--- a/lib/opsicle/commands/failure_log.rb
+++ b/lib/opsicle/commands/failure_log.rb
@@ -30,7 +30,7 @@ module Opsicle
           system("open", log_url) if log_url
           puts "Unable to find a url to open." unless log_url
         else
-          puts "There are either no failed deployments in available history or there are no available logs for failures."
+          puts "There is at least one failed deployment, but there is no log available for that failure."
         end
       else
         puts "No failed deployments in available history."


### PR DESCRIPTION
Description and Impact
----------------------
Because there are scenarios where a deployment fails, but there are no failure logs, so this will add a check for if there are no instances involved in a failed deployment.

Deploy Plan
-----------
* checkout master
* `op accept-pull 99`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Test out the command with a different .opsicle file and watch it not break

Previous output if there is no failure log:
![screen shot 2016-07-19 at 9 03 21 am](https://cloud.githubusercontent.com/assets/7562793/16952637/b46385a2-4d8f-11e6-9f60-1989347c64a0.png)


New output if there is no failure log:
![screen shot 2016-07-19 at 9 02 29 am](https://cloud.githubusercontent.com/assets/7562793/16952621/97364488-4d8f-11e6-9afe-c9d379b9eeb1.png)


