### PR TITLE
Adding configuration for authenticating to AWS through credentials file

### DIFF
--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -9,8 +9,9 @@ module Opsicle
     def initialize(environment)
       @config = Config.instance
       @config.configure_aws_environment!(environment)
-      @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
-      @s3 = Aws::S3::Client.new(region: 'us-east-1', credentials: @config.aws_credentials)
+      credentials = @config.aws_credentials
+      @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: credentials)
+      @s3 = Aws::S3::Client.new(region: 'us-east-1', credentials: credentials)
     end
 
     def run_command(command, command_args={}, options={})

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -85,6 +85,12 @@ module Opsicle
       return shared_credentials
     end
 
+    def get_sts_client(access_key_id, secret_access_key)
+      Aws::STS::Client.new(access_key_id: access_key_id,
+                           secret_access_key: secret_access_key,
+                           region: 'us-east-1')
+    end
+
     def get_session(mfa_token, mfa_serial_number, access_key_id, secret_access_key)
       return @session if @session
       sts = Aws::STS::Client.new(access_key_id: access_key_id,

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -37,7 +37,7 @@ module Opsicle
       env_config
     end
 
-     def get_mfa_token
+    def get_mfa_token
       return @token if @token
       @token = Output.ask("Enter MFA token: "){ |q|  q.validate = /^\d{6}$/ }
     end

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -5,6 +5,7 @@ module Opsicle
   class Config
     FOG_CONFIG_PATH = '~/.fog'
     OPSICLE_CONFIG_PATH = './.opsicle'
+    CREDS_CONFIG_PATH = '~/.aws/credentials'
     SESSION_DURATION = 3600
 
     attr_reader :environment
@@ -14,22 +15,16 @@ module Opsicle
     end
 
     def aws_credentials
-      Aws::Credentials.new(aws_config[:access_key_id], aws_config[:secret_access_key], aws_config[:session_token])
-    end
-
-    def aws_config
-      return @aws_config if @aws_config
-      if fog_config[:mfa_serial_number]
-        creds = get_session.credentials
-        @aws_config = { access_key_id: creds.access_key_id, secret_access_key: creds.secret_access_key, session_token: creds.session_token }
+      if credentials__config_exist?
+        authenticate_with_credentials
       else
-        @aws_config = { access_key_id: fog_config[:aws_access_key_id], secret_access_key: fog_config[:aws_secret_access_key] }
+        abort('I am no longer able to authenticate through your ~/.fog file. Please run `opsicle legacy-credential-converter` before proceeding.`')
       end
     end
 
-    def fog_config
-      return @fog_config if @fog_config
-      @fog_config = load_config(File.expand_path(FOG_CONFIG_PATH))
+    def credentials__config_exist?
+      return @cred_config if @cred_config
+      @cred_config = File.exist?(File.expand_path(CREDS_CONFIG_PATH))
     end
 
     def opsworks_config
@@ -38,7 +33,7 @@ module Opsicle
 
     def configure_aws_environment!(environment)
       @environment = environment.to_sym
-      end
+    end
 
     def load_config(file)
       raise MissingConfig, "Missing configuration file: #{file}  Run 'opsicle help'" unless File.exist?(file)
@@ -46,26 +41,6 @@ module Opsicle
       raise MissingEnvironment, "Configuration for the \'#{environment}\' environment could not be found in #{file}" unless env_config != nil
 
       env_config
-    end
-
-    def get_mfa_token
-      return @token if @token
-      @token = Output.ask("Enter MFA token: "){ |q|  q.validate = /^\d{6}$/ }
-    end
-
-    def get_session
-      return @session if @session
-      sts = Aws::STS::Client.new(access_key_id: fog_config[:aws_access_key_id],
-                                 secret_access_key: fog_config[:aws_secret_access_key],
-                                 region: 'us-east-1')
-      @session = sts.get_session_token(duration_seconds: session_duration,
-                                       serial_number: fog_config[:mfa_serial_number],
-                                       token_code: get_mfa_token)
-    end
-
-    def session_duration
-      fog_config = load_config(File.expand_path(FOG_CONFIG_PATH))
-      fog_config[:session_duration] || SESSION_DURATION
     end
 
     # We want all ouf our YAML loaded keys to be symbols
@@ -83,6 +58,41 @@ module Opsicle
         result[new_key] = new_value
         result
       }
+    end
+
+    def authenticate_with_credentials
+      shared_credentials = Aws::SharedCredentials.new(profile_name: @environment.to_s)
+      Aws.config.update({region: 'us-east-1', credentials: shared_credentials})
+
+      iam = Aws::IAM::Client.new
+
+       # this will be an array of 0 or 1 because iam.list_mfa_devices.mfa_devices will only return 0 or 1 device per user;
+       # if user doesn't have MFA enabled, then this loop won't even execute
+      iam.list_mfa_devices.mfa_devices.each do |mfadevice|
+        mfa_serial_number = mfadevice.serial_number
+        mfa_token = Output.ask("Enter MFA token: "){ |q|  q.validate = /^\d{6}$/ }
+        session_credentials_hash = get_session(mfa_token,
+                                               mfa_serial_number,
+                                               shared_credentials.credentials.access_key_id,
+                                               shared_credentials.credentials.secret_access_key).credentials
+
+        session_credentials = Aws::Credentials.new(session_credentials_hash.access_key_id,
+                                                   session_credentials_hash.secret_access_key,
+                                                   session_credentials_hash.session_token)
+        return session_credentials
+      end
+
+      return shared_credentials
+    end
+
+    def get_session(mfa_token, mfa_serial_number, access_key_id, secret_access_key)
+      return @session if @session
+      sts = Aws::STS::Client.new(access_key_id: access_key_id,
+                                 secret_access_key: secret_access_key,
+                                 region: 'us-east-1')
+      @session = sts.get_session_token(duration_seconds: SESSION_DURATION,
+                                       serial_number: mfa_serial_number,
+                                       token_code: mfa_token)
     end
 
     MissingConfig = Class.new(StandardError)

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -4,7 +4,6 @@ require 'aws-sdk'
 module Opsicle
   class Config
     OPSICLE_CONFIG_PATH = './.opsicle'
-    CREDS_CONFIG_PATH = '~/.aws/credentials'
     SESSION_DURATION = 3600
 
     attr_reader :environment

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -1,30 +1,18 @@
 require "spec_helper"
 require "opsicle"
+require "aws-sdk"
 
 module Opsicle
   describe Config do
     subject { Config.new }
     context "with a valid config" do
       before do
-        allow(File).to receive(:exist?).with(File.expand_path '~/.fog').and_return(true)
+        allow(File).to receive(:exist?).with(File.expand_path '~/.aws/credentials').and_return(true)
         allow(File).to receive(:exist?).with('./.opsicle').and_return(true)
-        allow(YAML).to receive(:load_file).with(File.expand_path '~/.fog').and_return({'derp' => { 'aws_access_key_id' => 'key', 'aws_secret_access_key' => 'secret'}})
         allow(YAML).to receive(:load_file).with('./.opsicle').and_return({'derp' => { 'app_id' => 'app', 'stack_id' => 'stack'}})
       end
       before :each do
         subject.configure_aws_environment!('derp')
-      end
-
-      context "#aws_config" do
-        it "should contain access_key_id" do
-          expect(subject.aws_config).to have_key(:access_key_id)
-          expect(subject.aws_config).to eq({ :access_key_id => 'key', :secret_access_key => 'secret'})
-        end
-
-        it "should contain secret_access_key" do
-          expect(subject.aws_config).to have_key(:secret_access_key)
-          expect(subject.aws_config).to eq({ :access_key_id => 'key', :secret_access_key => 'secret'})
-        end
       end
 
       context "#opsworks_config" do
@@ -38,10 +26,18 @@ module Opsicle
       end
 
       context "#aws_credentials" do
+        before :each do
+          mfa_devices = double('mfa_devices', mfa_devices: [])
+          iam_client = double('iam_client', list_mfa_devices: mfa_devices)
+          allow(Aws::IAM::Client).to receive(:new).and_return(iam_client)
+        end
+
         it "should return aws credentials" do
-          credentials = double
-          allow(Aws::Credentials).to receive(:new).and_return(credentials)
-          expect(subject.aws_credentials).to eq(credentials)
+          coffee_types = {:coffee => "cappuccino", :beans => "arabica"}
+          allow(Aws.config).to receive(:update).with({region: 'us-east-1', credentials: coffee_types})
+          allow(Aws::SharedCredentials).to receive(:new).and_return(coffee_types)
+          allow(Aws::Credentials).to receive(:new).and_return(coffee_types)
+          expect(subject.aws_credentials).to eq(coffee_types)
         end
       end
 
@@ -54,20 +50,7 @@ module Opsicle
 
     context "missing configs" do
       before do
-        allow(File).to receive(:exist?).with(File.expand_path '~/.fog').and_return(false)
         allow(File).to receive(:exist?).with('./.opsicle').and_return(false)
-      end
-
-      context "#aws_config" do
-        it "should gracefully raise an exception if no .fog file was found" do
-          expect {subject.aws_config}.to raise_exception(Config::MissingConfig)
-        end
-      end
-
-      context "#fog_config" do
-        it "should gracefully raise an exception if no .fog file was found" do
-          expect {subject.aws_config}.to raise_exception(Config::MissingConfig)
-        end
       end
 
       context "#opsworks_config" do

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -31,6 +31,7 @@ module Opsicle
           client = double('iam_client', list_mfa_devices: mfa_devices)
           allow(Aws::IAM::Client).to receive(:new).and_return(client)
           coffee_types = {:coffee => "cappuccino", :beans => "arabica"}
+          allow(coffee_types).to receive('set?').and_return(true)
           allow(Aws.config).to receive(:update).with({region: 'us-east-1', credentials: coffee_types})
           allow(Aws::SharedCredentials).to receive(:new).and_return(coffee_types)
           expect(subject.aws_credentials).to eq(coffee_types)


### PR DESCRIPTION
Description and Impact
----------------------
This gives the ability to authenticate to AWS through the ~/.aws/credentials file instead of through the ~/.fog file. This will no longer accept the fog file at all, and will ask users to run `opsicle legacy-credential-converter` before doing any more opsicle commands.

Deploy Plan
-----------
* checkout master
* `op accept-pull 99`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
http://docs.aws.amazon.com/sdkforruby/api/Aws/OpsWorks/Client.html

QA Plan
-------
- [x] Run without MFA set up to verify they work
  - [x] Run `bundle exec bin/opsicle --debug failure-log [account]`
<img width="948" alt="screen shot 2016-07-25 at 1 30 28 pm" src="https://cloud.githubusercontent.com/assets/7562793/17112549/195f5464-526c-11e6-9c3c-2f3ac101f347.png">

  - [x] Run `bundle exec bin/opsicle --debug deploy [account]`
<img width="881" alt="screen shot 2016-07-25 at 1 36 18 pm" src="https://cloud.githubusercontent.com/assets/7562793/17112773/15bdd370-526d-11e6-836a-f9d4ea37a6a7.png">

  - [x] Run several other commands and make sure they work
<img width="860" alt="screen shot 2016-07-25 at 1 36 34 pm" src="https://cloud.githubusercontent.com/assets/7562793/17112755/05190ac6-526d-11e6-8fc6-9ec303c5b235.png">

- [x] Run with MFA set up (will need to input an MFA key)
  - [x] Run `bundle exec bin/opsicle --debug failure-log [account]`
<img width="917" alt="screen shot 2016-07-25 at 1 26 34 pm" src="https://cloud.githubusercontent.com/assets/7562793/17112419/95f4a368-526b-11e6-9b8e-1d7a01f7fa64.png">

  - [x] Run `bundle exec bin/opsicle --debug deploy [account]`
<img width="880" alt="screen shot 2016-07-25 at 1 28 27 pm" src="https://cloud.githubusercontent.com/assets/7562793/17112455/c15ffa16-526b-11e6-979b-3daab06efd71.png">

  - [x] Run several other commands and make sure they work
<img width="852" alt="screen shot 2016-07-25 at 1 32 53 pm" src="https://cloud.githubusercontent.com/assets/7562793/17112669/9ed7a8ee-526c-11e6-9aa1-f994757ffcef.png">

