### PR TITLE
Make new directory for credentials file if it doesn't already exist

### DIFF
--- a/lib/opsicle/credential_converter_helper.rb
+++ b/lib/opsicle/credential_converter_helper.rb
@@ -3,8 +3,11 @@ require 'yaml'
 module Opsicle
   module CredentialConverterHelper
     def convert_fog_to_aws
-      # open/make new credentials file, read, and gather the groups of aws credentials already in file
+      directory_path = File.expand_path("~/.aws/")
       cred_path = File.expand_path("~/.aws/credentials")
+
+      # open/make new credentials file, read, and gather the groups of aws credentials already in file
+      Dir.mkdir(directory_path) unless File.directory?(directory_path)
       cred_file = File.open(cred_path, "a+")
       cred_text = cred_file.read
       cred_groups = cred_text.scan(/\[([\S]*)\]/).flatten

--- a/lib/opsicle/credential_converter_helper.rb
+++ b/lib/opsicle/credential_converter_helper.rb
@@ -4,11 +4,11 @@ module Opsicle
   module CredentialConverterHelper
     def convert_fog_to_aws
       directory_path = File.expand_path("~/.aws/")
-      cred_path = File.expand_path("~/.aws/credentials")
+      file_path = directory_path + "/credentials"
 
       # open/make new credentials file, read, and gather the groups of aws credentials already in file
       Dir.mkdir(directory_path) unless File.directory?(directory_path)
-      cred_file = File.open(cred_path, "a+")
+      cred_file = File.open(file_path, "a+")
       cred_text = cred_file.read
       cred_groups = cred_text.scan(/\[([\S]*)\]/).flatten
 


### PR DESCRIPTION
Description and Impact
----------------------
This will fix https://github.com/sportngin/opsicle/issues/103. When a user runs legacy-credential-converter but do not have the .aws directory, this will make it. Previously it would return an error.

Deploy Plan
-----------
* checkout master
* `op accept-pull 104`
* `soyuz deploy` and pick RubyGems with a patch release

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
- [x] Verify you do not have an `~/.aws/` directory or an `~/.aws/credentials` file
- [x] Run `bundle exec bin/opsicle legacy-credential-converter`
- [x] Verify there are no errors
- [x] Verify you now have the appropriate directories and files and they are accurate

