### PR TITLE
Only prompt for MFA if requested by the user

### DIFF
--- a/bin/opsicle
+++ b/bin/opsicle
@@ -21,11 +21,13 @@ DOCUMENTATION
 switch :verbose, :desc => 'Enable Verbose mode for more logging', :negatable => false
 switch :debug, :desc => 'Enable Debug mode for detailed logs and backtraces', :negatable => false
 switch :color, :desc => 'Use colored output', :default_value => true
+swtich :mfa, :desc => 'Use MFA for this command (some AWS operations will fail without it based on policy)', :negatable => false
 
 pre do |global_options, command, options, args|
   $verbose = global_options[:verbose]
   $debug = global_options[:debug]
   $color = global_options[:color]
+  $use_mfa = global_options[:mfa]
   ENV['GLI_DEBUG'] = $debug.to_s
   true
 end

--- a/bin/opsicle
+++ b/bin/opsicle
@@ -21,7 +21,7 @@ DOCUMENTATION
 switch :verbose, :desc => 'Enable Verbose mode for more logging', :negatable => false
 switch :debug, :desc => 'Enable Debug mode for detailed logs and backtraces', :negatable => false
 switch :color, :desc => 'Use colored output', :default_value => true
-swtich :mfa, :desc => 'Use MFA for this command (some AWS operations will fail without it based on policy)', :negatable => false
+switch :mfa, :desc => 'Use MFA for this command (some AWS operations will fail without it based on policy)', :negatable => false
 
 pre do |global_options, command, options, args|
   $verbose = global_options[:verbose]

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -67,16 +67,18 @@ module Opsicle
 
        # this will be an array of 0 or 1 because iam.list_mfa_devices.mfa_devices will only return 0 or 1 device per user;
        # if user doesn't have MFA enabled, then this loop won't even execute
-      iam.list_mfa_devices.mfa_devices.each do |mfadevice|
-        mfa_serial_number = mfadevice.serial_number
-        get_mfa_token
-        session_credentials_hash = get_session(mfa_serial_number,
-                                               credentials.credentials.access_key_id,
-                                               credentials.credentials.secret_access_key).credentials
+      if $use_mfa
+        iam.list_mfa_devices.mfa_devices.each do |mfadevice|
+          mfa_serial_number = mfadevice.serial_number
+          get_mfa_token
+          session_credentials_hash = get_session(mfa_serial_number,
+                                                 credentials.credentials.access_key_id,
+                                                 credentials.credentials.secret_access_key).credentials
 
-        credentials = Aws::Credentials.new(session_credentials_hash.access_key_id,
-                                                   session_credentials_hash.secret_access_key,
-                                                   session_credentials_hash.session_token)
+          credentials = Aws::Credentials.new(session_credentials_hash.access_key_id,
+                                                     session_credentials_hash.secret_access_key,
+                                                     session_credentials_hash.session_token)
+        end
       end
 
       return credentials


### PR DESCRIPTION
Description and Impact
----------------------
Since IAM can selectively enforce MFA for certain operations, it is not necessarily required across the board when present. This adds a switch to allow users to choose when to authenticate with MFA.

It is important to note that if you do not provide the MFA flag and the operation you are trying to execute requires MFA, the operation will fail. Simply add the MFA flag to make it work.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
 1. Make sure you can run commands without MFA even though you have an MFA token present on your account.
 1. Make sure adding the flag authenticates for MFA-required actions.