### PR TITLE
Support for configurable aws credentials profile name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,16 +24,16 @@ production:
   app_id: opsworks-app-id
 ```
 
-```yaml
-# ~/.fog
+Opsicle v2+ uses AWS SDK shared credentials.  See: https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/
+```ini
+# ~/.aws/credentials
 
-staging:
+[staging]
+  aws_access_key_id = YOUR_AWS_ACCESS_KEY
+  aws_secret_access_key = YOUR_AWS_SECRET_ACCESS_KEY
+[production]
   aws_access_key_id: YOUR_AWS_ACCESS_KEY
-  aws_secret_access_key: YOUR_AWS_SECRET_ACCESS_KEY
-production:
-  aws_access_key_id: YOUR_AWS_ACCESS_KEY
-  aws_secret_access_key: YOUR_AWS_SECRET_ACCESS_KEY
-  mfa_serial_number: YOUR_MFA_ID
+  aws_secret_access_key = YOUR_AWS_SECRET_ACCESS_KEY
 ```
 
 ## Using Opsicle

--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,10 @@ staging:
 production:
   stack_id: opsworks-stack-id
   app_id: opsworks-app-id
+production2:
+  stack_id: opsworks-stack-id
+  app_id: opsworks-app-id
+  profile_name: production
 ```
 
 Opsicle v2+ uses AWS SDK shared credentials.  See: https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -55,7 +55,8 @@ module Opsicle
     end
 
     def authenticate_with_credentials
-      credentials = Aws::SharedCredentials.new(profile_name: @environment.to_s)
+      profile_name = opsworks_config[:profile_name] || @environment.to_s
+      credentials = Aws::SharedCredentials.new(profile_name: profile_name)
 
       unless credentials.set?
         abort('Opsicle can no longer authenticate through your ~/.fog file. Please run `opsicle legacy-credential-converter` before proceeding.')

--- a/spec/opsicle/config_spec.rb
+++ b/spec/opsicle/config_spec.rb
@@ -36,6 +36,18 @@ module Opsicle
           allow(Aws::SharedCredentials).to receive(:new).and_return(coffee_types)
           expect(subject.aws_credentials).to eq(coffee_types)
         end
+
+        it "should suport configuarable profile name" do
+          allow(YAML).to receive(:load_file).with('./.opsicle').and_return({'derp' => { 'app_id' => 'app', 'stack_id' => 'stack', 'profile_name' => 'tacos' }})
+          mfa_devices = double('mfa_devices', mfa_devices: [])
+          client = double('iam_client', list_mfa_devices: mfa_devices)
+          allow(Aws::IAM::Client).to receive(:new).and_return(client)
+          coffee_types = {:coffee => "cappuccino", :beans => "arabica"}
+          allow(coffee_types).to receive('set?').and_return(true)
+          allow(Aws.config).to receive(:update).with({region: 'us-east-1', credentials: coffee_types})
+          allow(Aws::SharedCredentials).to receive(:new).with(profile_name: 'tacos').and_return(coffee_types)
+          expect(subject.aws_credentials).to eq(coffee_types)
+        end
       end
 
       context "#configure_aws_environment!" do


### PR DESCRIPTION
Description and Impact
----------------------
There are use cases where multiple opsicle environments can exist in the same AWS account, and thus may use the same AWS credentials profile.  Right now you have to copy them for each environment name.  This adds support to override the profile name as a config line in the `.opsicle` file with the continued default of the environment name.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Checkout branch, put a .opsicle file in place for testing, set the environment name to differ from an existing profile, and set the `profile_name` config.  Verify it works with various commands.

