### PR TITLE
Regional Endpoints

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,7 @@ production2:
   stack_id: opsworks-stack-id
   app_id: opsworks-app-id
   profile_name: production
+  region: us-west-2
 ```
 
 Opsicle v2+ uses AWS SDK shared credentials.  See: https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/
@@ -93,11 +94,11 @@ opsicle monitor staging
 ```bash
  # Upload a cookbooks directory to S3 and update the stack's custom cookbooks
  opsicle chef-update staging --bucket-name my-opsworks-cookbooks
- 
+
 ```
 This command accepts a --path argument to the directory of cookbooks to upload. It defaults to 'cookbooks'.
 It also accepts a --bucket-name for the base s3 bucket. This flag is required.
- 
+
 ### Update
 Update an OpsWorks resource like a stack, layer or app with a given set of property values.
 The values can be passed as inline JSON or as a path to a YAML file.

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -12,7 +12,7 @@ module Opsicle
       credentials = @config.aws_credentials
       region = @config.opsworks_region
       @opsworks = Aws::OpsWorks::Client.new(region: region, credentials: credentials)
-      @s3 = Aws::S3::Client.new(region: 'us-east-1', credentials: credentials)
+      @s3 = Aws::S3::Client.new(region: region, credentials: credentials)
     end
 
     def run_command(command, command_args={}, options={})

--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -10,7 +10,8 @@ module Opsicle
       @config = Config.instance
       @config.configure_aws_environment!(environment)
       credentials = @config.aws_credentials
-      @opsworks = Aws::OpsWorks::Client.new(region: 'us-east-1', credentials: credentials)
+      region = @config.opsworks_region
+      @opsworks = Aws::OpsWorks::Client.new(region: region, credentials: credentials)
       @s3 = Aws::S3::Client.new(region: 'us-east-1', credentials: credentials)
     end
 

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -20,6 +20,10 @@ module Opsicle
       @opsworks_config ||= load_config(OPSICLE_CONFIG_PATH)
     end
 
+    def opsworks_region
+      opsworks_config[:region] || "us-east-1"
+    end
+
     def configure_aws_environment!(environment)
       @environment = environment.to_sym
     end

--- a/lib/opsicle/config.rb
+++ b/lib/opsicle/config.rb
@@ -61,12 +61,13 @@ module Opsicle
     def authenticate_with_credentials
       profile_name = opsworks_config[:profile_name] || @environment.to_s
       credentials = Aws::SharedCredentials.new(profile_name: profile_name)
+      region = opsworks_region
 
       unless credentials.set?
         abort('Opsicle can no longer authenticate through your ~/.fog file. Please run `opsicle legacy-credential-converter` before proceeding.')
       end
 
-      Aws.config.update({region: 'us-east-1', credentials: credentials})
+      Aws.config.update({region: region, credentials: credentials})
 
       iam = Aws::IAM::Client.new
 

--- a/spec/opsicle/client_spec.rb
+++ b/spec/opsicle/client_spec.rb
@@ -10,6 +10,7 @@ module Opsicle
       mock_keys = {access_key_id: 'key', secret_access_key: 'secret'}
       allow(config).to receive(:aws_credentials).and_return(mock_keys)
       allow(config).to receive(:opsworks_config).and_return({ stack_id: 'stack', app_id: 'app', something_else: 'true' })
+      allow(config).to receive(:opsworks_region).and_return('us-east-1')
       allow(Config).to receive(:new).and_return(config)
       allow(Config).to receive(:instance).and_return(config)
       allow(Aws::OpsWorks::Client).to receive(:new).and_return(aws_client)


### PR DESCRIPTION
Description and Impact
----------------------
Makes possible to use regional endpoints to query AWS API against

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
http://docs.aws.amazon.com/general/latest/gr/rande.html#opsworks_region

QA Plan
-------
- [x] Create a new OpsWorks stack in `us-east-2` region and add it to `opsicle` config file, but don't specify the region
- [x] Execute `opsicle chef-update ENVIRONMENT` command which should fail with `Unable to find stack with ID`
- [x] Add `region: us-east-2` to `opsicle` config file
- [x] Execute `opsicle chef-update ENVIRONMENT` command, which should succeed