### PR TITLE
Add ability to override AMI id, agent version, and instance type when cloning an instance

### DIFF
--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -29,6 +29,8 @@ module Opsicle
     end
 
     def clone(options)
+      puts "\nCloning an instance..."
+      
       new_instance_hostname = make_new_hostname(self.hostname)
       ami_id = verify_ami_id
       agent_version = verify_agent_version

--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -29,43 +29,85 @@ module Opsicle
     end
 
     def clone(options)
-      all_sibling_hostnames = self.layer.instances.collect { |instance| instance.hostname }
-      new_instance_hostname = make_new_hostname(self.hostname, all_sibling_hostnames)
-      puts "\nWe will make a new instance with hostname: #{new_instance_hostname}"
-
-      options[:ami] ? ami_id = options[:ami] : ami_id = self.ami_id
-      options[:instance_type] ? instance_type = options[:instance_type] : instance_type = self.instance_type
-      options[:agent_version] ? agent_version = options[:agent_version] : agent_version = self.agent_version
+      new_instance_hostname = make_new_hostname(self.hostname)
+      ami_id = verify_ami_id
+      agent_version = verify_agent_version
+      instance_type = verify_instance_type
 
       create_new_instance(new_instance_hostname, instance_type, ami_id, agent_version)
     end
 
-    def make_new_hostname(old_hostname, all_hostnames)
+    def make_new_hostname(old_hostname)
+      all_sibling_hostnames = self.layer.instances.collect { |instance| instance.hostname }
+
       if old_hostname =~ /\d\d\z/
-        new_instance_hostname = increment_hostname(old_hostname, all_hostnames)
+        new_instance_hostname = increment_hostname(old_hostname, all_sibling_hostnames)
       else
         new_instance_hostname = old_hostname << "_clone"
       end
         
       puts "\nAutomatically generated hostname: #{new_instance_hostname}\n"
       rewriting = @cli.ask("Do you wish to rewrite this hostname?\n1) Yes\n2) No", Integer)
-
-      if rewriting == 1
-        new_instance_hostname = @cli.ask("Please write in the new instance's hostname and press ENTER:")
-      end
+      new_instance_hostname = @cli.ask("Please write in the new instance's hostname and press ENTER:") if rewriting == 1
 
       new_instance_hostname
     end
 
-    def increment_hostname(hostname, all_hostnames)
-      until hostname_unique?(hostname, all_hostnames) do
+    def increment_hostname(hostname, all_sibling_hostnames)
+      until hostname_unique?(hostname, all_sibling_hostnames) do
         hostname = hostname.gsub(/(\d\d\z)/) { "#{($1.to_i + 1).to_s.rjust(2, '0')}" }
       end
       hostname
     end
 
-    def hostname_unique?(hostname, all_hostnames)
-      !all_hostnames.include?(hostname)
+    def hostname_unique?(hostname, all_sibling_hostnames)
+      !all_sibling_hostnames.include?(hostname)
+    end
+
+    def verify_ami_id
+      if self.layer.ami_id
+        ami_id = self.layer.ami_id
+      else
+        puts "\nCurrent AMI id is #{self.ami_id}"
+        rewriting = @cli.ask("Do you wish to override this AMI? By overriding, you are choosing to override the current AMI for all instances you are cloning.\n1) Yes\n2) No", Integer)
+        ami_id = rewriting == 1 ? @cli.ask("Please write in the new AMI id press ENTER:") : self.ami_id
+      end
+
+      self.layer.ami_id = ami_id
+      ami_id
+    end
+
+    def verify_agent_version
+      if self.layer.agent_version
+        agent_version = self.layer.agent_version
+      else
+        puts "\nCurrent agent version is #{self.agent_version}"
+        rewriting = @cli.ask("Do you wish to override this version? By overriding, you are choosing to override the current agent version for all instances you are cloning.\n1) Yes\n2) No", Integer)
+        agent_version = rewriting == 1 ? get_new_agent_version : self.agent_version
+      end
+
+      self.layer.agent_version = agent_version
+      agent_version
+    end
+
+    def get_new_agent_version
+      agents = @opsworks.describe_agent_versions(stack_id: self.stack_id).agent_versions
+
+      version_ids = []
+      agents.each do |agent|
+        version_ids << agent.version
+      end
+
+      version_ids.each_with_index { |id, index| puts "#{index.to_i + 1}) #{id}"}
+      id_index = @cli.ask("Which agent version ID?\n", Integer) { |q| q.in = 1..version_ids.length.to_i } - 1
+      version_ids[id_index]
+    end
+
+    def verify_instance_type
+      puts "\nCurrent instance type is #{self.instance_type}"
+      rewriting = @cli.ask("Do you wish to override this instance type?\n1) Yes\n2) No", Integer)
+      instance_type = rewriting == 1 ? @cli.ask("Please write in the new instance type press ENTER:") : self.instance_type
+      instance_type
     end
 
     def create_new_instance(new_instance_hostname, instance_type, ami_id, agent_version)
@@ -88,7 +130,7 @@ module Opsicle
         agent_version: agent_version,
         tenancy: self.tenancy,
       })
-      puts "New instance is created: #{new_instance.instance_id}"
+      puts "\nNew instance has been created: #{new_instance.instance_id}"
     end
   end
 end

--- a/lib/opsicle/cloneable_layer.rb
+++ b/lib/opsicle/cloneable_layer.rb
@@ -1,6 +1,6 @@
 module Opsicle
   class CloneableLayer
-    attr_accessor :name, :layer_id, :instances, :opsworks, :cli
+    attr_accessor :name, :layer_id, :instances, :opsworks, :cli, :agent_version, :ami_id
 
     def initialize(name, layer_id, opsworks, cli)
       self.name = name

--- a/lib/opsicle/commands/clone_instance.rb
+++ b/lib/opsicle/commands/clone_instance.rb
@@ -24,6 +24,9 @@ module Opsicle
       instances_to_clone.each do |instance|
         instance.clone(options)
       end
+      
+      layer.ami_id = nil
+      layer.agent_version = nil
     end
 
     def select_layer

--- a/spec/opsicle/cloneable_instance_spec.rb
+++ b/spec/opsicle/cloneable_instance_spec.rb
@@ -15,7 +15,11 @@ module Opsicle
                                        :subnet_id => 'subnet_id', :architecture => 'architecture',
                                        :root_device_type => 'root_device_type', :install_updates_on_boot => 'install_updates_on_boot',
                                        :ebs_optimized => 'ebs_optimized', :tenancy => 'tenancy')
-      @layer = double('layer1', :name => 'layer-1', :layer_id => 12345, :instances => [@instance])
+      @layer = double('layer1', :name => 'layer-1', :layer_id => 12345, :instances => [@instance], :ami_id => nil, :agent_version => nil)
+      allow(@layer).to receive(:ami_id=)
+      allow(@layer).to receive(:ami_id)
+      allow(@layer).to receive(:agent_version=)
+      allow(@layer).to receive(:agent_version)
       @new_instance = double('new_instance', :instance_id => 1029384756)
       @opsworks = double('opsworks', :create_instance => @new_instance)
       @cli = double('cli', :ask => 2)
@@ -25,7 +29,18 @@ module Opsicle
       it "should make a unique incremented hostname" do
         instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
         expect(instance).to receive(:increment_hostname).and_return('example-hostname-03')
-        instance.make_new_hostname('example-hostname-01', ['example-hostname-01', 'example-hostname-02'])
+        instance1 = double('instance', :hostname => 'example-hostname-01')
+        instance2 = double('instance', :hostname => 'example-hostname-02')
+        allow(@layer).to receive(:instances).and_return([instance1, instance2])
+        instance.make_new_hostname('example-hostname-01')
+      end
+
+      it "should make a unique incremented hostname" do
+        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance1 = double('instance', :hostname => 'example-hostname-01')
+        instance2 = double('instance', :hostname => 'example-hostname-02')
+        expect(@layer).to receive(:instances).and_return([instance1, instance2])
+        instance.make_new_hostname('example-hostname-01')
       end
     end
 
@@ -40,16 +55,15 @@ module Opsicle
     context "#clone" do
       it "should grab instances and make new hostname" do
         instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
-        expect(@layer).to receive(:instances)
         expect(instance).to receive(:make_new_hostname).and_return('example-hostname-03')
         instance.clone({})
       end
 
       it "should get information from old instance" do
         instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
-        expect(instance).to receive(:agent_version)
-        expect(instance).to receive(:ami_id)
-        expect(instance).to receive(:instance_type)
+        expect(instance).to receive(:verify_ami_id)
+        expect(instance).to receive(:verify_agent_version)
+        expect(instance).to receive(:verify_instance_type)
         instance.clone({})
       end
 
@@ -57,6 +71,51 @@ module Opsicle
         instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
         expect(instance).to receive(:create_new_instance)
         instance.clone({})
+      end
+    end
+
+    context '#verify_agent_version' do
+      it "should check the agent version and ask if the user wants a new agent version" do
+        @cli = double('cli', :ask => 1)
+        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        allow(@layer).to receive(:agent_version).and_return(nil)
+        allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this version? By overriding, you are choosing to override the current agent version for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(1)
+        expect(instance).to receive(:get_new_agent_version)
+        instance.verify_agent_version
+      end
+
+      it "should see if the layer already has overwritten the agent version" do
+        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        expect(@layer).to receive(:agent_version)
+        instance.verify_agent_version
+      end
+    end
+
+    context '#verify_ami_id' do
+      it "should check the ami id and ask if the user wants a new ami" do
+        @cli = double('cli', :ask => 1)
+        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        allow(@layer).to receive(:ami_id).and_return(nil)
+        allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this AMI? By overriding, you are choosing to override the current AMI for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(1)
+        expect(@cli).to receive(:ask).twice
+        instance.verify_ami_id
+      end
+
+      it "should see if the layer already has overwritten the ami id" do
+        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        expect(@layer).to receive(:ami_id)
+        instance.verify_ami_id
+      end
+    end
+
+    context '#verify_instance_type' do
+      it "should check the agent version and ask if the user wants a new agent version" do
+        @cli = double('cli', :ask => 1)
+        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        allow(@layer).to receive(:ami_id).and_return(nil)
+        allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this instance type?\n1) Yes\n2) No", Integer).and_return(1)
+        expect(@cli).to receive(:ask).twice
+        instance.verify_instance_type
       end
     end
 

--- a/spec/opsicle/commands/clone_instance_spec.rb
+++ b/spec/opsicle/commands/clone_instance_spec.rb
@@ -41,6 +41,12 @@ module Opsicle
       allow_any_instance_of(HighLine).to receive(:ask).with("Instances? (enter as a comma separated list)\n", String).and_return('2')
       allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to rewrite this hostname?\n1) Yes\n2) No", Integer).and_return(2)
       allow_any_instance_of(HighLine).to receive(:ask).with("Please write in the new instance's hostname and press ENTER:").and_return('example-hostname')
+      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this AMI? By overriding, you are choosing to override the current AMI for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(2)
+      allow_any_instance_of(HighLine).to receive(:ask).with("Please write in the new AMI id press ENTER:").and_return('example-ami')
+      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this version? By overriding, you are choosing to override the current agent version for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(2)
+      allow_any_instance_of(HighLine).to receive(:ask).with("Which agent version ID?\n", Integer).and_return(1)
+      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this instance type?\n1) Yes\n2) No", Integer).and_return(2)
+      allow_any_instance_of(HighLine).to receive(:ask).with("Please write in the new instance type press ENTER:").and_return('t2.micro')
     end
     
     context "#execute" do


### PR DESCRIPTION
Description and Impact
----------------------
When cloning instances, ask the user if they want to provide a specific AMI id, agent version, and instance type, instead of the ones used by the instance they're cloning. This is handy when the user may be intentionally trying to clone instances while updating the AMIs or something like that.

Deploy Plan
-----------
- checkout master
- `op accept-pull 112`
- `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run the command `bundle exec bin/opsicle --debug clone-instance [account]`
- [x] Verify it asks to specify AMI id and agent version **once per run**
- [x] Verify it asks to update instance type **once per clone**
- [x] Verify if choosing to specify agent version that it provides a list of options (this feature is currently unavailable for AMIs or instance types)
