### PR TITLE
Generate valid hostnames when source hostname doesn't end with digits

### DIFF
--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -45,7 +45,7 @@ module Opsicle
       if old_hostname =~ /\d\d\z/
         new_instance_hostname = increment_hostname(old_hostname, all_sibling_hostnames)
       else
-        new_instance_hostname = old_hostname << "_clone"
+        new_instance_hostname = old_hostname << "-clone"
       end
         
       puts "\nAutomatically generated hostname: #{new_instance_hostname}\n"


### PR DESCRIPTION
What
----------------------
Append `-clone` instead of `_clone` to cloned instances' hostnames.

Why
----------------------
In some cases, `_clone` gets appended to autogenerated hostnames of cloned instances and the hostname becomes invalid because of the underscore in it.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://github.com/sportngin/opsicle/issues/117

QA Plan
-------
- [x] Clone an instance which hostname doesn't end with digits
![image](https://cloud.githubusercontent.com/assets/5482411/24732079/26f7aadc-1a34-11e7-961c-72c77d5c2326.png)
