### PR TITLE
require minitar ~> 0.6

### DIFF
--- a/opsicle.gemspec
+++ b/opsicle.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gli", "~> 2.9"
   spec.add_dependency "highline", "~> 1.6"
   spec.add_dependency "terminal-table", "~> 1.4"
-  spec.add_dependency "minitar", "~> 0.5"
+  spec.add_dependency "minitar", "~> 0.6"
   spec.add_dependency "hashdiff", "~> 0.2"
   spec.add_dependency "curses", "~> 1.0.2"
 


### PR DESCRIPTION
v0.5.1 was exhibiting strange behavior for me on OS X Sierra
(recursively adding to the cookbooks being tar'd up) until I updated to
the latest version of the gem.

Would be nice to ensure that a more recent copy of the gem is installed
with opsicle.