### PR TITLE
Make each generated hostname unique when counting up

### DIFF
--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -132,6 +132,7 @@ module Opsicle
         agent_version: agent_version,
         tenancy: self.tenancy,
       })
+      self.layer.add_new_instance(new_instance.instance_id)
       puts "\nNew instance has been created: #{new_instance.instance_id}"
     end
   end

--- a/lib/opsicle/cloneable_layer.rb
+++ b/lib/opsicle/cloneable_layer.rb
@@ -17,5 +17,10 @@ module Opsicle
       end
       self.instances
     end
+
+    def add_new_instance(instance_id)
+      instance = @opsworks.describe_instances({ :instance_ids => [instance_id] }).instances.first
+      self.instances << CloneableInstance.new(instance, self, @opsworks, @cli)
+    end
   end
 end

--- a/spec/opsicle/cloneable_instance_spec.rb
+++ b/spec/opsicle/cloneable_instance_spec.rb
@@ -20,6 +20,7 @@ module Opsicle
       allow(@layer).to receive(:ami_id)
       allow(@layer).to receive(:agent_version=)
       allow(@layer).to receive(:agent_version)
+      allow(@layer).to receive(:add_new_instance)
       @new_instance = double('new_instance', :instance_id => 1029384756)
       @opsworks = double('opsworks', :create_instance => @new_instance)
       @cli = double('cli', :ask => 2)
@@ -39,8 +40,10 @@ module Opsicle
         instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
         instance1 = double('instance', :hostname => 'example-hostname-01')
         instance2 = double('instance', :hostname => 'example-hostname-02')
-        expect(@layer).to receive(:instances).and_return([instance1, instance2])
-        instance.make_new_hostname('example-hostname-01')
+        instance3 = double('instance', :hostname => 'example-hostname-03')
+        instance4 = double('instance', :hostname => 'example-hostname-04')
+        expect(@layer).to receive(:instances).and_return([instance1, instance2, instance3, instance4])
+        expect(instance.make_new_hostname('example-hostname-01')).to eq('example-hostname-05')
       end
     end
 

--- a/spec/opsicle/cloneable_layer_spec.rb
+++ b/spec/opsicle/cloneable_layer_spec.rb
@@ -24,7 +24,17 @@ module Opsicle
                                        :subnet_id => 'subnet_id', :architecture => 'architecture',
                                        :root_device_type => 'root_device_type', :install_updates_on_boot => 'install_updates_on_boot',
                                        :ebs_optimized => 'ebs_optimized', :tenancy => 'tenancy')
+      @instance3 = double('instance3', :hostname => 'example-hostname-03', :status => 'stopped',
+                                       :ami_id => 'ami_id', :instance_type => 'instance_type',
+                                       :agent_version => 'agent_version', :stack_id => 1234567890,
+                                       :layer_ids => [12345, 67890], :auto_scaling_type => 'auto_scaling_type',
+                                       :os => 'os', :ssh_key_name => 'ssh_key_name',
+                                       :availability_zone => 'availability_zone', :virtualization_type => 'virtualization_type',
+                                       :subnet_id => 'subnet_id', :architecture => 'architecture',
+                                       :root_device_type => 'root_device_type', :install_updates_on_boot => 'install_updates_on_boot',
+                                       :ebs_optimized => 'ebs_optimized', :tenancy => 'tenancy')
       @instances = double('instances', :instances => [@instance1, @instance2])
+      @new_instance = double('new_instance', :instances => [@instance3])
       @opsworks = double('opsworks', :describe_instances => @instances)
     end
 
@@ -40,6 +50,22 @@ module Opsicle
         layer = CloneableLayer.new('layer-name', 12345, @opsworks, @cli)
         expect(CloneableInstance).to receive(:new).twice
         layer.get_cloneable_instances
+      end
+    end
+
+    context "#add_new_instance" do
+      it "should accurately find a new instance via instance_id" do
+        layer = CloneableLayer.new('layer-name', 12345, @opsworks, @cli)
+        expect(@opsworks).to receive(:describe_instances).and_return(@new_instance)
+        expect(@new_instance).to receive(:instances)
+        layer.add_new_instance('456-789')
+      end
+
+      it "should add the new instance to the instances array" do
+        layer = CloneableLayer.new('layer-name', 12345, @opsworks, @cli)
+        expect(@opsworks).to receive(:describe_instances).and_return(@new_instance)
+        expect(CloneableInstance).to receive(:new).once
+        layer.add_new_instance('456-789')
       end
     end
   end


### PR DESCRIPTION
Description and Impact
----------------------
When cloning multiple numbered instance, the first hostname generated is always unique, thanks to `increment_hostname` and `hostname_unique?`. But, when generating sequential hostnames, the check `hostname_unique?` does not account for newly created instances that were made just before. So, now we must add newly created instances to the layer so that `hostname_unique?` will see those newly created instances.

Deploy Plan
-----------
- checkout master
- `op accept-pull 121`
- `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run the command `bundle exec bin/opsicle --debug clone-instance [account]`
- [x] Intentionally clone two or more instances at the same time
- [x] Rewrite the first instance's hostname so that the numbering is following the numbering of another cloneable instance (ex: if first instance cloning is 9, and second instance cloning is 13, then rewrite hostname of new instance to be 14)
- [x] Verify the auto-generated hostname when cloning the second instance is **not** 14, but rather 15