### PR TITLE
Display Layer short name instead of readable name to make it easier to copy/paste

### DIFF
--- a/lib/opsicle/stack.rb
+++ b/lib/opsicle/stack.rb
@@ -27,7 +27,7 @@ module Opsicle
     end
 
     def layer_name(layer_id)
-      layers.detect{ |layer| layer[:layer_id] == layer_id }[:name]
+      layers.detect{ |layer| layer[:layer_id] == layer_id }[:shortname]
     end
 
   end


### PR DESCRIPTION
What
----------------------
Use shortname for layers when running the instance command.

Why
----------------------
> Why is this being changed?  Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA/A-HA/etc links may not be available in the future.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

- [x] Build the gem locally and run instance command.
- [x] Verify that layer name is using shortname specified in AWS console.

