### PR TITLE
Make new clones of instances with only the Subnet ID

### DIFF
--- a/lib/opsicle/client.rb
+++ b/lib/opsicle/client.rb
@@ -3,6 +3,7 @@ require 'opsicle/config'
 module Opsicle
   class Client
     attr_reader :opsworks
+    attr_reader :ec2
     attr_reader :s3
     attr_reader :config
 
@@ -14,6 +15,7 @@ module Opsicle
       aws_opts = {region: region}
       aws_opts[:credentials] = credentials unless credentials.nil?
       @opsworks = Aws::OpsWorks::Client.new aws_opts
+      @ec2 = Aws::EC2::Client.new aws_opts
       @s3 = Aws::S3::Client.new aws_opts
     end
 

--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -212,9 +212,9 @@ module Opsicle
         os: self.os,
         ami_id: ami_id,
         ssh_key_name: self.ssh_key_name,
-        availability_zone: self.availability_zone,
-        virtualization_type: self.virtualization_type,
+        # availability_zone: self.availability_zone, # we don't need availability zone if subnet ID is set
         subnet_id: subnet_id,
+        virtualization_type: self.virtualization_type,
         architecture: self.architecture, # accepts x86_64, i386
         root_device_type: self.root_device_type, # accepts ebs, instance-store
         install_updates_on_boot: self.install_updates_on_boot,

--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -116,9 +116,7 @@ module Opsicle
     def find_subnet_name(subnet)
       tags = subnet.tags
       tag = nil
-      tags.each do |t|
-        tag = t if t.key == 'Name'
-      end
+      tags.each { |t| tag = t if t.key == 'Name' }
       tag.value if tag
     end
 
@@ -170,8 +168,8 @@ module Opsicle
         subnet_id = self.layer.subnet_id
       else
         current_subnet = Aws::EC2::Subnet.new(id: self.subnet_id)
-        tag_name = find_subnet_name(current_subnet)
-        puts "\nCurrent subnet ID is \"#{tag_name}\" #{current_subnet.availability_zone} (#{self.subnet_id})"
+        subnet_name = find_subnet_name(current_subnet)
+        puts "\nCurrent subnet ID is \"#{subnet_name}\" #{current_subnet.availability_zone} (#{self.subnet_id})"
 
         if ask_for_overriding_permission("subnet ID", true)
           ec2_subnets = ec2.describe_subnets.subnets
@@ -179,10 +177,10 @@ module Opsicle
 
           ec2_subnets.each do |subnet|
             if subnet.vpc_id == stack.vpc_id
-              tag_name = find_subnet_name(subnet)
+              subnet_name = find_subnet_name(subnet)
               zone_name = subnet.availability_zone
               subnet_id = subnet.subnet_id
-              subnets << "\"#{tag_name}\" #{zone_name} (#{subnet_id})"
+              subnets << "\"#{subnet_name}\" #{zone_name} (#{subnet_id})"
             end
           end
 

--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -177,7 +177,7 @@ module Opsicle
             subnet_id = ask_for_new_option('subnet ID')
           end
 
-          subnet_id = subnet_id.scan(/(subnet-\S*)/).first.first
+          subnet_id = subnet_id.scan(/(subnet-\S*)/).first.first if subnet_id
         else
           subnet_id = self.subnet_id
         end

--- a/lib/opsicle/cloneable_instance.rb
+++ b/lib/opsicle/cloneable_instance.rb
@@ -222,7 +222,7 @@ module Opsicle
         os: self.os,
         ami_id: ami_id,
         ssh_key_name: self.ssh_key_name,
-        # availability_zone: self.availability_zone, # we don't need availability zone if subnet ID is set
+        # availability_zone: self.availability_zone,
         subnet_id: subnet_id,
         virtualization_type: self.virtualization_type,
         architecture: self.architecture, # accepts x86_64, i386

--- a/lib/opsicle/cloneable_layer.rb
+++ b/lib/opsicle/cloneable_layer.rb
@@ -1,11 +1,13 @@
 module Opsicle
   class CloneableLayer
-    attr_accessor :name, :layer_id, :instances, :opsworks, :cli, :agent_version, :ami_id, :subnet_id
+    attr_accessor :name, :layer_id, :stack, :instances, :opsworks, :ec2, :cli, :agent_version, :ami_id, :subnet_id
 
-    def initialize(name, layer_id, opsworks, cli)
+    def initialize(name, layer_id, stack, opsworks, ec2, cli)
       self.name = name
       self.layer_id = layer_id
+      self.stack = stack
       self.opsworks = opsworks
+      self.ec2 = ec2
       self.cli = cli
       self.instances = []
     end
@@ -13,14 +15,14 @@ module Opsicle
     def get_cloneable_instances
       ops_instances = @opsworks.describe_instances({ :layer_id => layer_id }).instances
       ops_instances.each do |instance|
-        self.instances << CloneableInstance.new(instance, self, @opsworks, @cli)
+        self.instances << CloneableInstance.new(instance, self, stack, @opsworks, @ec2, @cli)
       end
       self.instances
     end
 
     def add_new_instance(instance_id)
       instance = @opsworks.describe_instances({ :instance_ids => [instance_id] }).instances.first
-      self.instances << CloneableInstance.new(instance, self, @opsworks, @cli)
+      self.instances << CloneableInstance.new(instance, self, stack, @opsworks, @ec2, @cli)
     end
   end
 end

--- a/lib/opsicle/cloneable_stack.rb
+++ b/lib/opsicle/cloneable_stack.rb
@@ -1,11 +1,12 @@
 module Opsicle
   class CloneableStack
-    attr_accessor :id, :opsworks, :stack
+    attr_accessor :id, :opsworks, :stack, :vpc_id
 
     def initialize(stack_id, opsworks)
       self.id = stack_id
       self.opsworks = opsworks
       self.stack = get_stack
+      self.vpc_id = self.stack.vpc_id
     end
 
     def get_stack

--- a/lib/opsicle/commands/clone_instance.rb
+++ b/lib/opsicle/commands/clone_instance.rb
@@ -10,6 +10,7 @@ module Opsicle
     def initialize(environment)
       @client = Client.new(environment)
       @opsworks = @client.opsworks
+      @ec2 = @client.ec2
       stack_id = @client.config.opsworks_config[:stack_id]
       @stack = CloneableStack.new(@client.config.opsworks_config[:stack_id], @opsworks)
       @cli = HighLine.new
@@ -39,7 +40,7 @@ module Opsicle
 
       layers = []
       ops_layers.each do |layer|
-        layers << CloneableLayer.new(layer.name, layer.layer_id, @opsworks, @cli)
+        layers << CloneableLayer.new(layer.name, layer.layer_id, @stack, @opsworks, @ec2, @cli)
       end
 
       layers.each_with_index { |layer, index| puts "#{index.to_i + 1}) #{layer.name}"}

--- a/spec/opsicle/cloneable_instance_spec.rb
+++ b/spec/opsicle/cloneable_instance_spec.rb
@@ -25,19 +25,29 @@ module Opsicle
       allow(@layer).to receive(:subnet_id)
       @new_instance = double('new_instance', :instance_id => 1029384756)
       @opsworks = double('opsworks', :create_instance => @new_instance)
+      @ec2 = double('ec2')
+      @stack = double('stack')
       @agent_version_1 = double('agent_version', :version => '3434-20160316181345')
       @agent_version_2 = double('agent_version', :version => '3435-20160406115841')
       @agent_version_3 = double('agent_version', :version => '3436-20160418214624')
       @agent_versions = double('agent_versions', :agent_versions => [@agent_version_1, @agent_version_2, @agent_version_3])
       allow(@opsworks).to receive(:describe_agent_versions).with({:stack_id=>1234567890}).and_return(@agent_versions)
+      tag1 = double('tag', :value => 'Subnet')
+      @tags = [tag1]
+      @subnet1 = double('subnet', :vpc_id => 'vpc-123456', :subnet_id => 'subnet-123456', :tags => @tags)
+      @subnet2 = double('subnet', :vpc_id => 'vpc-123456', :subnet_id => 'subnet-789123', :tags => @tags)
+      @subnet3 = double('subnet', :vpc_id => 'vpc-123456', :subnet_id => 'subnet-456789', :tags => @tags)
+      @subnets = double('subnets', :subnets => [@subnet1, @subnet2, @subnet3])
+      allow(@stack).to receive(:vpc_id).and_return('vpc-123456')
       @instances = double('instances', :instances => [@instance])
+      allow(@ec2).to receive(:describe_subnets).and_return(@subnets)
       allow(@opsworks).to receive(:describe_instances).with({:stack_id=>1234567890}).and_return(@instances)
       @cli = double('cli', :ask => 2)
     end
 
     context "#make_new_hostname" do
       it "should make a unique incremented hostname" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         instance1 = double('instance', :hostname => 'example-hostname-01')
         instance2 = double('instance', :hostname => 'example-hostname-02')
         allow(@layer).to receive(:instances).and_return([instance1, instance2])
@@ -45,7 +55,7 @@ module Opsicle
       end
 
       it "should make a unique incremented hostname" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         instance1 = double('instance', :hostname => 'example-hostname-01')
         instance2 = double('instance', :hostname => 'example-hostname-02')
         instance3 = double('instance', :hostname => 'example-hostname-03')
@@ -57,7 +67,7 @@ module Opsicle
 
     context "#increment_hostname" do
       it "should increment the hostname" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(instance).to receive(:hostname_unique?).and_return('example-hostname-03')
         allow(@opsworks).to receive(:describe_agent_version).with({})
         expect(instance.increment_hostname).to eq('example-hostname-01')
@@ -66,13 +76,13 @@ module Opsicle
 
     context "#clone" do
       it "should grab instances and make new hostname" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(instance).to receive(:make_new_hostname).and_return('example-hostname-03')
         instance.clone({})
       end
 
       it "should get information from old instance" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(instance).to receive(:verify_ami_id)
         expect(instance).to receive(:verify_agent_version)
         expect(instance).to receive(:verify_instance_type)
@@ -81,13 +91,13 @@ module Opsicle
       end
 
       it "should create new instance" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(instance).to receive(:create_new_instance)
         instance.clone({})
       end
 
       it "should start new instance" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         allow(instance).to receive(:ask_to_start_instance).and_return(true)
         expect(instance).to receive(:start_new_instance)
         instance.clone({})
@@ -97,7 +107,7 @@ module Opsicle
     context '#verify_agent_version' do
       it "should check the agent version and ask if the user wants a new agent version" do
         @cli = double('cli', :ask => 1)
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         allow(@layer).to receive(:agent_version).and_return(nil)
         allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this version? By overriding, you are choosing to override the current agent version for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(1)
         expect(instance).to receive(:ask_for_possible_options)
@@ -105,7 +115,7 @@ module Opsicle
       end
 
       it "should see if the layer already has overwritten the agent version" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(@layer).to receive(:agent_version)
         instance.verify_agent_version
       end
@@ -114,7 +124,7 @@ module Opsicle
     context '#verify_subnet_id' do
       it "should check the subnet id and ask if the user wants a new subnet id" do
         @cli = double('cli', :ask => 1)
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         allow(@layer).to receive(:subnet_id).and_return(nil)
         allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this id? By overriding, you are choosing to override the current agent version for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(1)
         subnet_dummy = double('subnet_dummy', :availability_zone => 'us-east-1b', :map_public_ip_on_launch => true)
@@ -124,7 +134,7 @@ module Opsicle
       end
 
       it "should see if the layer already has overwritten the subnet id" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(@layer).to receive(:subnet_id)
         instance.verify_subnet_id
       end
@@ -133,7 +143,7 @@ module Opsicle
     context '#verify_ami_id' do
       it "should check the ami id and ask if the user wants a new ami" do
         @cli = double('cli', :ask => 1)
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         allow(@layer).to receive(:ami_id).and_return(nil)
         allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this AMI? By overriding, you are choosing to override the current AMI for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(1)
         expect(@cli).to receive(:ask)
@@ -142,7 +152,7 @@ module Opsicle
       end
 
       it "should see if the layer already has overwritten the ami id" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(@layer).to receive(:ami_id)
         instance.verify_ami_id
       end
@@ -151,7 +161,7 @@ module Opsicle
     context '#verify_instance_type' do
       it "should check the agent version and ask if the user wants a new agent version" do
         @cli = double('cli', :ask => 1)
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         allow(@layer).to receive(:ami_id).and_return(nil)
         allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this instance type?\n1) Yes\n2) No", Integer).and_return(1)
         expect(@cli).to receive(:ask).twice
@@ -161,13 +171,13 @@ module Opsicle
 
     context "#create_new_instance" do
       it "should create an instance" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(@opsworks).to receive(:create_instance)
         instance.create_new_instance('hostname', 'type', 'ami', 'agent_version', 'subnet_id')
       end
 
       it "should take information from old instance" do
-        instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
+        instance = CloneableInstance.new(@instance, @layer, @stack, @opsworks, @ec2, @cli)
         expect(instance).to receive(:stack_id)
         expect(instance).to receive(:layer_ids)
         expect(instance).to receive(:auto_scaling_type)

--- a/spec/opsicle/cloneable_instance_spec.rb
+++ b/spec/opsicle/cloneable_instance_spec.rb
@@ -117,6 +117,8 @@ module Opsicle
         instance = CloneableInstance.new(@instance, @layer, @opsworks, @cli)
         allow(@layer).to receive(:subnet_id).and_return(nil)
         allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this id? By overriding, you are choosing to override the current agent version for all instances you are cloning.\n1) Yes\n2) No", Integer).and_return(1)
+        subnet_dummy = double('subnet_dummy', :availability_zone => 'us-east-1b', :map_public_ip_on_launch => true)
+        allow(Aws::EC2::Subnet).to receive(:new).and_return(subnet_dummy)
         expect(instance).to receive(:ask_for_possible_options)
         instance.verify_subnet_id
       end
@@ -171,7 +173,6 @@ module Opsicle
         expect(instance).to receive(:auto_scaling_type)
         expect(instance).to receive(:os)
         expect(instance).to receive(:ssh_key_name)
-        expect(instance).to receive(:availability_zone)
         expect(instance).to receive(:virtualization_type)
         instance.create_new_instance('hostname', 'type', 'ami', 'agent_version', 'subnet_id')
       end

--- a/spec/opsicle/cloneable_layer_spec.rb
+++ b/spec/opsicle/cloneable_layer_spec.rb
@@ -36,18 +36,20 @@ module Opsicle
       @instances = double('instances', :instances => [@instance1, @instance2])
       @new_instance = double('new_instance', :instances => [@instance3])
       @opsworks = double('opsworks', :describe_instances => @instances)
+      @ec2 = double('ec2')
+      @stack = double('stack')
     end
 
     context "#get_cloneable_instances" do
       it "should gather opsworks instances for that layer" do
-        layer = CloneableLayer.new('layer-name', 12345, @opsworks, @cli)
+        layer = CloneableLayer.new('layer-name', 12345, @stack, @opsworks, @ec2, @cli)
         expect(@opsworks).to receive(:describe_instances).and_return(@instances)
         expect(@instances).to receive(:instances)
         layer.get_cloneable_instances
       end
 
       it "should make a new CloneableInstance for each instance" do
-        layer = CloneableLayer.new('layer-name', 12345, @opsworks, @cli)
+        layer = CloneableLayer.new('layer-name', 12345, @stack, @opsworks, @ec2, @cli)
         expect(CloneableInstance).to receive(:new).twice
         layer.get_cloneable_instances
       end
@@ -55,14 +57,14 @@ module Opsicle
 
     context "#add_new_instance" do
       it "should accurately find a new instance via instance_id" do
-        layer = CloneableLayer.new('layer-name', 12345, @opsworks, @cli)
+        layer = CloneableLayer.new('layer-name', 12345, @stack, @opsworks, @ec2, @cli)
         expect(@opsworks).to receive(:describe_instances).and_return(@new_instance)
         expect(@new_instance).to receive(:instances)
         layer.add_new_instance('456-789')
       end
 
       it "should add the new instance to the instances array" do
-        layer = CloneableLayer.new('layer-name', 12345, @opsworks, @cli)
+        layer = CloneableLayer.new('layer-name', 12345, @stack, @opsworks, @ec2, @cli)
         expect(@opsworks).to receive(:describe_instances).and_return(@new_instance)
         expect(CloneableInstance).to receive(:new).once
         layer.add_new_instance('456-789')

--- a/spec/opsicle/cloneable_stack_spec.rb
+++ b/spec/opsicle/cloneable_stack_spec.rb
@@ -6,7 +6,7 @@ require "opsicle/user_profile"
 module Opsicle
   describe CloneableStack do
     before do
-      @stack = double('stack')
+    @stack = double('stack', :vpc_id => 'vpc-123456')
       @stacks = double('stacks', :stacks => [@stack])
       @opsworks = double('opsworks', :describe_stacks => @stacks)
     end

--- a/spec/opsicle/commands/clone_instance_spec.rb
+++ b/spec/opsicle/commands/clone_instance_spec.rb
@@ -44,6 +44,10 @@ module Opsicle
       @agent_version_3 = double('agent_version', :version => '3436-20160418214624')
       @agent_versions = double('agent_versions', :agent_versions => [@agent_version_1, @agent_version_2, @agent_version_3])
       allow(@opsworks).to receive(:describe_agent_versions).and_return(@agent_versions)
+      tag1 = double('tag', :value => 'Subnet', :key => 'Name')
+      @tags = [tag1]
+      @current_subnet = double('subnet', :tags => @tags, :availability_zone => 'us-east-1b')
+      allow(Aws::EC2::Subnet).to receive(:new).and_return(@current_subnet)
       allow_any_instance_of(HighLine).to receive(:ask).with("Layer?\n", Integer).and_return(2)
       allow_any_instance_of(HighLine).to receive(:ask).with("Instances? (enter as a comma separated list)\n", String).and_return('2')
       allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this hostname?\n1) Yes\n2) No", Integer).and_return(2)

--- a/spec/opsicle/commands/clone_instance_spec.rb
+++ b/spec/opsicle/commands/clone_instance_spec.rb
@@ -29,13 +29,14 @@ module Opsicle
       @layer2 = double('layer2', :name => 'layer-2', :layer_id => 67890, :instances => [@instance1, @instance2])
       @layers = double('layers', :layers => [@layer1, @layer2])
       @new_instance = double('new_instance', :instance_id => 1029384756)
-      @stack = double('stack')
+      @stack = double('stack', :vpc_id => "vpc-123456")
       @stacks = double('stacks', :stacks => [@stack])
       @opsworks = double('opsworks', :describe_instances => @instances, :describe_layers => @layers,
                                      :create_instance => @new_instance, :describe_stacks => @stacks,
                                      :start_instance => @new_instance)
+      @ec2 = double('ec2')
       @config = double('config', :opsworks_config => {:stack_id => 1234567890})
-      @client = double('client', :config => @config, :opsworks => @opsworks)
+      @client = double('client', :config => @config, :opsworks => @opsworks, :ec2 => @ec2)
       allow(Client).to receive(:new).with(:environment).and_return(@client)
       allow(@instances).to receive(:each_with_index)
       @agent_version_1 = double('agent_version', :version => '3434-20160316181345')
@@ -93,7 +94,8 @@ module Opsicle
       it "generates a new AWS client from the given configs" do
         @config = double('config', :opsworks_config => {:stack_id => 1234567890})
         @client = double('client', :config => @config,
-                                   :opsworks => @opsworks)
+                                   :opsworks => @opsworks,
+                                   :ec2 => @ec2)
         expect(Client).to receive(:new).with(:environment).and_return(@client)
         CloneInstance.new(:environment)
       end


### PR DESCRIPTION
Description and Impact
----------------------
Avoid scenario were new subnet ID and old availability zone would clash and instances wouldn't be created. Since we only need one of the parameters to make a new instance, use the changed or verified subnet ID only (ignore availability zones). Also, the command should print more information about each subnet, including the zone, the official name which includes data about public/private, and the original ID. This PR will also fix https://github.com/sportngin/opsicle/pull/128.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run `bundle exec bin/opsicle --debug clone-instance [account]`
- [x] Watch a new instance be created with the same subnet ID
- [x] Run the command again and use a difference subnet ID
- [x] Watch a new instance be created in a new subnet ID
- [x] Run the command again and write in a subnet (with long or short form)
- [x] Watch a new instance be made no matter whether you wrote the long or short form of subnet ID