### PR TITLE
Show private IPs of instances in `opsicle instances env` command

### DIFF
--- a/lib/opsicle/commands/list_instances.rb
+++ b/lib/opsicle/commands/list_instances.rb
@@ -18,12 +18,12 @@ module Opsicle
     end
 
     def print(instances)
-      puts Terminal::Table.new headings: ['Hostname', 'Layers', 'Status', 'Private IP', 'Instance ID'], rows: instance_data(instances)
+      puts Terminal::Table.new headings: ['Hostname', 'Layers', 'Status', 'Public IP', 'Private ID'], rows: instance_data(instances)
     end
 
     def instance_data(instances)
       instances.sort { |a,b| a[:hostname] <=> b[:hostname] }.map { |instance|
-        [instance[:hostname], layer_names(instance), instance[:status], Opsicle::Instances::pretty_ip(instance), instance[:instance_id]]
+        [instance[:hostname], layer_names(instance), instance[:status], Opsicle::Instances::pretty_ip(instance), Opsicle::Instances::private_ip(instance)]
       }
     end
 

--- a/lib/opsicle/commands/list_instances.rb
+++ b/lib/opsicle/commands/list_instances.rb
@@ -18,7 +18,7 @@ module Opsicle
     end
 
     def print(instances)
-      puts Terminal::Table.new headings: ['Hostname', 'Layers', 'Status', 'IP', 'Instance ID'], rows: instance_data(instances)
+      puts Terminal::Table.new headings: ['Hostname', 'Layers', 'Status', 'Private IP', 'Instance ID'], rows: instance_data(instances)
     end
 
     def instance_data(instances)

--- a/lib/opsicle/commands/list_instances.rb
+++ b/lib/opsicle/commands/list_instances.rb
@@ -18,7 +18,7 @@ module Opsicle
     end
 
     def print(instances)
-      puts Terminal::Table.new headings: ['Hostname', 'Layers', 'Status', 'Public IP', 'Private ID'], rows: instance_data(instances)
+      puts Terminal::Table.new headings: ['Hostname', 'Layers', 'Status', 'Public IP', 'Private IP'], rows: instance_data(instances)
     end
 
     def instance_data(instances)

--- a/lib/opsicle/instances.rb
+++ b/lib/opsicle/instances.rb
@@ -15,12 +15,12 @@ module Opsicle
     end
 
     def self.pretty_ip(instance)
-      instance[:elastic_ip] ? "#{instance[:elastic_ip]} EIP" : instance[:public_ip]
+      instance[:private_ip]
     end
 
     def self.find_by_ip(client, ips)
       instances = new(client).data.reject { |instance| instances_matching_ips(instance, ips) }
-      instances.empty? ? nil : instances 
+      instances.empty? ? nil : instances
     end
 
     def self.instances_matching_ips(instance, ip_addresses)
@@ -32,7 +32,7 @@ module Opsicle
 
     def self.find_by_eip(client)
       instances =  new(client).data.reject { |instance| instance[:elastic_ip] == nil }
-      instances.empty? ? nil : instances 
+      instances.empty? ? nil : instances
     end
 
     def instances(options={})

--- a/lib/opsicle/instances.rb
+++ b/lib/opsicle/instances.rb
@@ -15,6 +15,10 @@ module Opsicle
     end
 
     def self.pretty_ip(instance)
+      instance[:elastic_ip] ? "#{instance[:elastic_ip]} EIP" : instance[:public_ip]
+    end
+
+    def self.private_ip(instance)
       instance[:private_ip]
     end
 

--- a/lib/opsicle/version.rb
+++ b/lib/opsicle/version.rb
@@ -1,3 +1,3 @@
 module Opsicle
-  VERSION = "2.9.3"
+  VERSION = "2.9.4"
 end


### PR DESCRIPTION
What
----------------------
Show private IPs instead of EIP or public IP.

Why
----------------------
Most of the time, we want to use private IPs for ssh-ing into the server. Public IPs are not used as highly as private IPs. This will allow users to see the private IPs.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Checkout this branch and build the gem `gem build opsicle.gemspec`. 
- [x] Install it locally to one of the gemsets of a project that uses opsicle.
- [x] Run `opsicle instances staging`.
- [x] Verify that it shows private IPs of the servers.
- [x] Go to the AWS Opsworks console and verify that the private IP in the instances match.