### PR TITLE
Show instance size and zone when listing instances

### DIFF
--- a/lib/opsicle/commands/list_instances.rb
+++ b/lib/opsicle/commands/list_instances.rb
@@ -18,13 +18,34 @@ module Opsicle
     end
 
     def print(instances)
-      puts Terminal::Table.new headings: ['Hostname', 'Layers', 'Status', 'Public IP', 'Private IP'], rows: instance_data(instances)
+      puts Terminal::Table.new(
+        headings: [
+          'Hostname',
+          'Size',
+          'Layers',
+          'Status',
+          'Public IP',
+          'Private IP',
+          'Zone'
+        ],
+        rows: instance_data(instances)
+      )
     end
 
     def instance_data(instances)
-      instances.sort { |a,b| a[:hostname] <=> b[:hostname] }.map { |instance|
-        [instance[:hostname], layer_names(instance), instance[:status], Opsicle::Instances::pretty_ip(instance), Opsicle::Instances::private_ip(instance)]
-      }
+      instances
+        .sort { |a,b| a[:hostname] <=> b[:hostname] }
+        .map do |instance|
+          [
+            instance[:hostname],
+            instance[:instance_type],
+            layer_names(instance),
+            instance[:status],
+            Opsicle::Instances::pretty_ip(instance),
+            Opsicle::Instances::private_ip(instance),
+            instance[:availability_zone]
+          ]
+        end
     end
 
     def layer_names(instance)

--- a/lib/opsicle/version.rb
+++ b/lib/opsicle/version.rb
@@ -1,3 +1,3 @@
 module Opsicle
-  VERSION = "2.11.1"
+  VERSION = "2.11.2"
 end


### PR DESCRIPTION
What
----------------------
See title ☝️.

Why
----------------------
It makes `opsicle instances ENV` more useful.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Reference commonly used Regression test plans on the [QA Wiki](https://github.com/sportngin/qa-tests/wiki)
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

- [x] `cd ~/sportngin/opsicle; git checkout show_size_and_zone_instances`
- [x] `gem build opsicle.gemspec`
- [x] `cd ../ngin`
- [x] `gem install ../opsicle/opsicle-2.11.2.gem`
- [x] `opsicle --version # make sure it's 2.11.2`
- [x] `opsicle instances staging`
- [x] Should have size and zone columns.