### PR TITLE
Use opsworks adapter on create_instance command file

### DIFF
--- a/lib/opsicle/commands/clone_instance.rb
+++ b/lib/opsicle/commands/clone_instance.rb
@@ -10,9 +10,9 @@ module Opsicle
 
     def initialize(environment)
       @client = Client.new(environment)
-      @opsworks_adapater = OpsworksAdapter.new(@client)
+      @opsworks_adapter = OpsworksAdapter.new(@client)
       stack_id = @client.config.opsworks_config[:stack_id]
-      @stack = ManageableStack.new(stack_id, @opsworks_adapater.client)
+      @stack = ManageableStack.new(stack_id, @opsworks_adapter.client)
       @cli = HighLine.new
     end
 
@@ -36,11 +36,11 @@ module Opsicle
 
     def select_layer
       puts "\nLayers:\n"
-      ops_layers = @opsworks_adapater.get_layers(@stack.id)
+      ops_layers = @opsworks_adapter.get_layers(@stack.id)
 
       layers = []
       ops_layers.each do |layer|
-        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks_adapater.client, @client.ec2, @cli)
+        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks_adapter.client, @client.ec2, @cli)
       end
 
       layers.each_with_index { |layer, index| puts "#{index.to_i + 1}) #{layer.name}" }

--- a/lib/opsicle/commands/create_instance.rb
+++ b/lib/opsicle/commands/create_instance.rb
@@ -1,5 +1,6 @@
 require 'gli'
 require "opsicle/user_profile"
+require "opsicle/opsworks_adapter"
 require "opsicle/manageable_layer"
 require "opsicle/manageable_stack"
 require "opsicle/creatable_instance"
@@ -9,10 +10,9 @@ module Opsicle
 
     def initialize(environment)
       @client = Client.new(environment)
-      @opsworks = @client.opsworks
-      @ec2 = @client.ec2
+      @opsworks_adapter = OpsworksAdapter.new(@client)
       stack_id = @client.config.opsworks_config[:stack_id]
-      @stack = ManageableStack.new(@client.config.opsworks_config[:stack_id], @opsworks)
+      @stack = ManageableStack.new(stack_id, @opsworks_adapter.client)
       @cli = HighLine.new
     end
 
@@ -31,11 +31,11 @@ module Opsicle
 
     def select_layer
       puts "\nLayers:\n"
-      ops_layers = @opsworks.describe_layers({ :stack_id => @stack.id }).layers
+      ops_layers = @opsworks_adapter.get_layers(@stack.id)
 
       layers = []
       ops_layers.each do |layer|
-        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks, @ec2, @cli)
+        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks_adapter.client, @client.ec2, @cli)
       end
 
       layers.each_with_index { |layer, index| puts "#{index.to_i + 1}) #{layer.name}" }

--- a/lib/opsicle/commands/create_instance.rb
+++ b/lib/opsicle/commands/create_instance.rb
@@ -26,7 +26,7 @@ module Opsicle
     end
 
     def create_instance(layer, options)
-      CreatableInstance.new(layer, @stack, @opsworks, @ec2, @cli).create(options)
+      CreatableInstance.new(layer, @stack, @opsworks_adapter.client, @client.ec2, @cli).create(options)
     end
 
     def select_layer


### PR DESCRIPTION
What
----------------------
Use the preexisting opsworks_adapter on the `create_instance` command file to simplify.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Clone this repository (if not already cloned)
- [x] `git pull` to update it
- [x] Checkout this branch
- [x] `rm *.gem` to be safe
- [x] `gem build opsicle.gemspec`
- [x] Go to a test directory (I use `ngin_bar`)
- [x] `gem install <path to opsicle dir>/*.gem`
- [x] Run `bundle exec bin/opsicle --debug clone-instance staging` to verify we can still clone instances
- [x] Run `bundle exec bin/opsicle --debug create-instance staging` to verify we can still create instances
- [x] Go back to opsicle directory
- [x] `rm *.gem`