### PR TITLE
Use opsworks adapter on other command files

### DIFF
--- a/lib/opsicle/commands/add_tags.rb
+++ b/lib/opsicle/commands/add_tags.rb
@@ -9,10 +9,9 @@ module Opsicle
 
     def initialize(environment)
       @client = Client.new(environment)
-      @opsworks = @client.opsworks
-      @ec2 = @client.ec2
+      @opsworks_adapter = OpsworksAdapter.new(@client)
       stack_id = @client.config.opsworks_config[:stack_id]
-      @stack = ManageableStack.new(@client.config.opsworks_config[:stack_id], @opsworks)
+      @stack = ManageableStack.new(stack_id, @opsworks_adapter.client)
       @cli = HighLine.new
     end
 
@@ -30,11 +29,11 @@ module Opsicle
 
     def select_layer
       puts "\nLayers:\n"
-      ops_layers = @opsworks.describe_layers({ :stack_id => @stack.id }).layers
+      ops_layers = @opsworks_adapter.get_layers(@stack.id)
 
       layers = []
       ops_layers.each do |layer|
-        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks, @ec2, @cli)
+        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks_adapter.client, @client.ec2, @cli)
       end
 
       layers.each_with_index { |layer, index| puts "#{index.to_i + 1}) #{layer.name}" }

--- a/lib/opsicle/commands/add_tags.rb
+++ b/lib/opsicle/commands/add_tags.rb
@@ -1,5 +1,6 @@
 require 'gli'
 require "opsicle/user_profile"
+require "opsicle/opsworks_adapter"
 require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"

--- a/lib/opsicle/commands/delete_instance.rb
+++ b/lib/opsicle/commands/delete_instance.rb
@@ -9,10 +9,9 @@ module Opsicle
 
     def initialize(environment)
       @client = Client.new(environment)
-      @opsworks = @client.opsworks
-      @ec2 = @client.ec2
+      @opsworks_adapter = OpsworksAdapter.new(@client)
       stack_id = @client.config.opsworks_config[:stack_id]
-      @stack = ManageableStack.new(@client.config.opsworks_config[:stack_id], @opsworks)
+      @stack = ManageableStack.new(stack_id, @opsworks_adapter.client)
       @cli = HighLine.new
     end
 
@@ -22,7 +21,7 @@ module Opsicle
       instances_to_delete = select_instances(layer)
       instances_to_delete.each do |instance|
         begin
-          @opsworks.delete_instance(instance_id: instance.instance_id)
+          @opsworks_adapter.delete_instance(instance.instance_id)
           puts "Successfully deleted #{instance.hostname}"
         rescue
           puts "Failed to delete #{instance.hostname}"
@@ -36,11 +35,11 @@ module Opsicle
 
     def select_layer
       puts "\nLayers:\n"
-      ops_layers = @opsworks.describe_layers({ :stack_id => @stack.id }).layers
+      ops_layers = @opsworks_adapter.get_layers(@stack_id)
 
       layers = []
       ops_layers.each do |layer|
-        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks, @ec2, @cli)
+        layers << ManageableLayer.new(layer.name, layer.layer_id, @stack, @opsworks_adapter.client, @client.ec2, @cli)
       end
 
       layers.each_with_index { |layer, index| puts "#{index.to_i + 1}) #{layer.name}" }

--- a/lib/opsicle/commands/delete_instance.rb
+++ b/lib/opsicle/commands/delete_instance.rb
@@ -1,5 +1,6 @@
 require 'gli'
 require "opsicle/user_profile"
+require "opsicle/opsworks_adapter"
 require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"

--- a/lib/opsicle/commands/move_eip.rb
+++ b/lib/opsicle/commands/move_eip.rb
@@ -9,11 +9,10 @@ module Opsicle
 
     def initialize(environment)
       @client = Client.new(environment)
-      @opsworks = @client.opsworks
-      @ec2 = @client.ec2
+      @opsworks_adpater = OpsworksAdapter.new(@client)
       stack_id = @client.config.opsworks_config[:stack_id]
       @cli = HighLine.new
-      @stack = ManageableStack.new(@client.config.opsworks_config[:stack_id], @opsworks, @cli)
+      @stack = ManageableStack.new(stack_id, @opsworks_adpater.client, @cli)
     end
 
     def execute(options={})

--- a/lib/opsicle/commands/move_eip.rb
+++ b/lib/opsicle/commands/move_eip.rb
@@ -1,5 +1,6 @@
 require 'gli'
 require "opsicle/user_profile"
+require "opsicle/opsworks_adapter"
 require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"

--- a/lib/opsicle/commands/stop_instance.rb
+++ b/lib/opsicle/commands/stop_instance.rb
@@ -1,5 +1,6 @@
 require 'gli'
 require "opsicle/user_profile"
+require "opsicle/opsworks_adapter"
 require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"

--- a/lib/opsicle/opsworks_adapter.rb
+++ b/lib/opsicle/opsworks_adapter.rb
@@ -12,4 +12,8 @@ class Opsicle::OpsworksAdapter
   def start_instance(instance_id)
     client.start_instance(instance_id: instance_id)
   end
+
+  def delete_instance(instance_id)
+    client.delete_instance(instance_id: instance_id)
+  end
 end

--- a/lib/opsicle/opsworks_adapter.rb
+++ b/lib/opsicle/opsworks_adapter.rb
@@ -13,6 +13,10 @@ class Opsicle::OpsworksAdapter
     client.start_instance(instance_id: instance_id)
   end
 
+  def stop_instance(instance_id)
+    client.stop_instance(instance_id: instance_id)
+  end
+
   def delete_instance(instance_id)
     client.delete_instance(instance_id: instance_id)
   end

--- a/spec/opsicle/opsworks_adapter_spec.rb
+++ b/spec/opsicle/opsworks_adapter_spec.rb
@@ -30,6 +30,13 @@ describe Opsicle::OpsworksAdapter do
     end
   end
 
+  describe "#stop_instance" do
+    it "should call stop_instance on the opsworks client" do
+      expect(aws_opsworks_client).to receive(:stop_instance).with(instance_id: :instance_id)
+      subject.stop_instance(:instance_id)
+    end
+  end
+
   describe "#delete_instance" do
     it "should call delete_instance on the opsworks client" do
       expect(aws_opsworks_client).to receive(:delete_instance).with(instance_id: :instance_id)

--- a/spec/opsicle/opsworks_adapter_spec.rb
+++ b/spec/opsicle/opsworks_adapter_spec.rb
@@ -1,11 +1,10 @@
 describe Opsicle::OpsworksAdapter do
   let(:aws_opsworks_client) do
-    double(
-     :aws_opsworks_client,
-     describe_layers: double(:layers, layers: []),
-     start_instance: :successful_response,
-     stop_instance: :successful_response,
-     delete_instance: :successful_response
+    double(:aws_opsworks_client,
+      describe_layers: double(:layers, layers: []),
+      start_instance: :started,
+      stop_instance: :stopped,
+      delete_instance: :deleted
     )
   end
   let(:client) { double(:client, opsworks: aws_opsworks_client) }
@@ -22,19 +21,19 @@ describe Opsicle::OpsworksAdapter do
 
   describe "#start_instance" do
     it "should call start_instance on the opsworks client" do
-      expect(subject.start_instance(:instance_id)).to eq(:successful_response)
+      expect(subject.start_instance(:instance_id)).to eq(:started)
     end
   end
 
   describe "#stop_instance" do
     it "should call stop_instance on the opsworks client" do
-      expect(subject.stop_instance(:instance_id)).to eq(:successful_response)
+      expect(subject.stop_instance(:instance_id)).to eq(:stopped)
     end
   end
-  
+
   describe "#delete_instance" do
     it "should call delete_instance on the opsworks client" do
-      expect(subject.delete_instance(:instance_id)).to eq(:successful_response)
+      expect(subject.delete_instance(:instance_id)).to eq(:deleted)
     end
   end
 end

--- a/spec/opsicle/opsworks_adapter_spec.rb
+++ b/spec/opsicle/opsworks_adapter_spec.rb
@@ -3,7 +3,9 @@ describe Opsicle::OpsworksAdapter do
     double(
      :aws_opsworks_client,
      describe_layers: double(:layers, layers: []),
-     start_instance: true
+     start_instance: :successful_response,
+     stop_instance: :successful_response,
+     delete_instance: :successful_response
     )
   end
   let(:client) { double(:client, opsworks: aws_opsworks_client) }
@@ -16,31 +18,23 @@ describe Opsicle::OpsworksAdapter do
     it "should gather an array of layers for this opsworks client" do
       expect(get_layers).to be_empty
     end
-
-    it "should call describe_layers on the opsworks client" do
-      expect(aws_opsworks_client).to receive(:describe_layers).with(stack_id: :stack_id)
-      get_layers
-    end
   end
 
   describe "#start_instance" do
     it "should call start_instance on the opsworks client" do
-      expect(aws_opsworks_client).to receive(:start_instance).with(instance_id: :instance_id)
-      subject.start_instance(:instance_id)
+      expect(subject.start_instance(:instance_id)).to eq(:successful_response)
     end
   end
 
   describe "#stop_instance" do
     it "should call stop_instance on the opsworks client" do
-      expect(aws_opsworks_client).to receive(:stop_instance).with(instance_id: :instance_id)
-      subject.stop_instance(:instance_id)
+      expect(subject.stop_instance(:instance_id)).to eq(:successful_response)
     end
   end
-
+  
   describe "#delete_instance" do
     it "should call delete_instance on the opsworks client" do
-      expect(aws_opsworks_client).to receive(:delete_instance).with(instance_id: :instance_id)
-      subject.delete_instance(:instance_id)
+      expect(subject.delete_instance(:instance_id)).to eq(:successful_response)
     end
   end
 end

--- a/spec/opsicle/opsworks_adapter_spec.rb
+++ b/spec/opsicle/opsworks_adapter_spec.rb
@@ -29,4 +29,11 @@ describe Opsicle::OpsworksAdapter do
       subject.start_instance(:instance_id)
     end
   end
+
+  describe "#delete_instance" do
+    it "should call delete_instance on the opsworks client" do
+      expect(aws_opsworks_client).to receive(:delete_instance).with(instance_id: :instance_id)
+      subject.delete_instance(:instance_id)
+    end
+  end
 end


### PR DESCRIPTION
What
----------------------
Use the preexisting opsworks_adapter on the `stop_instance`, `delete_instance`, `move_eip`, `add_tags` command files to simplify.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Clone this repository (if not already cloned)
- [x] `git pull` to update it
- [x] Checkout this branch
- [x] `rm *.gem` to be safe
- [x] `gem build opsicle.gemspec`
- [x] Go to a test directory (I use `ngin_bar`)
- [x] `gem install <path to opsicle dir>/*.gem`
- [x] Run `bundle exec bin/opsicle --debug stop-instance staging` to verify we can still stop instances
- [x] Run `bundle exec bin/opsicle --debug delete-instance staging` to verify we can still delete instances
- [x] Run `bundle exec bin/opsicle --debug move-eip staging` to verify we can still move eips
- [x] Run `bundle exec bin/opsicle --debug add-tags staging` to verify we can still add tags