### PR TITLE
Fix bugs that make it so deleting/stopping instances and moving EIPs sometimes breaks

### DIFF
--- a/lib/opsicle/commands/delete_instance.rb
+++ b/lib/opsicle/commands/delete_instance.rb
@@ -36,7 +36,7 @@ module Opsicle
 
     def select_layer
       puts "\nLayers:\n"
-      ops_layers = @opsworks_adapter.get_layers(@stack_id)
+      ops_layers = @opsworks_adapter.get_layers(@stack.id)
 
       layers = []
       ops_layers.each do |layer|

--- a/lib/opsicle/commands/stop_instance.rb
+++ b/lib/opsicle/commands/stop_instance.rb
@@ -36,7 +36,7 @@ module Opsicle
 
     def select_layer
       puts "\nLayers:\n"
-      ops_layers = @opsworks_adpater.get_layers(@stack.id)
+      ops_layers = @opsworks_adapter.get_layers(@stack.id)
 
       layers = []
       ops_layers.each do |layer|

--- a/lib/opsicle/manageable_stack.rb
+++ b/lib/opsicle/manageable_stack.rb
@@ -23,6 +23,7 @@ module Opsicle
       eip_information = []
 
       @eips.each do |eip|
+        next unless eip.instance_id
         instance_id = eip.instance_id
         instance = @opsworks.describe_instances(instance_ids: [instance_id]).instances.first
         instance_name = instance.hostname


### PR DESCRIPTION
What
----------------------
Deleting instances breaks currently. Stopping instances breaks. Moving EIPs break if any EIPs aren't connected to an instance. Fix the bugs so these don't break.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Clone this repository (if not already cloned)
- [x] git pull to update it
- [x] Checkout this branch
- [x] `rm *.gem to be safe`
- [x] `gem build opsicle.gemspec`
- [x] Go to a test directory (I use ngin_bar or ngin)
- [x] `gem install <path to opsicle dir>/*.gem`
- [x] Run `bundle exec bin/opsicle --debug stop-instance staging` to verify we can stop instances
- [x] Run `bundle exec bin/opsicle --debug delete-instance staging` to verify we can delete instances
- [x] Run `bundle exec bin/opsicle --debug move-eip staging` on a stack with unused EIPs to verify we can still move eips