### PR TITLE
Address various little bugs in code

### DIFF
--- a/lib/opsicle/commands/delete_instance.rb
+++ b/lib/opsicle/commands/delete_instance.rb
@@ -6,8 +6,6 @@ require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"
 
-require "pry"
-
 module Opsicle
   class DeleteInstance
 

--- a/lib/opsicle/commands/delete_instance.rb
+++ b/lib/opsicle/commands/delete_instance.rb
@@ -60,11 +60,7 @@ module Opsicle
         instances.each_with_index { |instance, index| puts "#{index.to_i + 1}) #{instance.status} - #{instance.hostname}" }
         instance_indices_string = @cli.ask("Which instances would you like to delete? (enter as a comma separated list)\n", String)
         instance_indices_list = instance_indices_string.split(/,\s*/)
-
-        if instance_indices_list.include?("0")
-          raise StandardError, "Any instances to delete must be indicated with numbers > 0."
-        end
-
+        check_for_valid_indices!(instance_indices_list, instances.count)
         instance_indices_list.map! { |instance_index| instance_index.to_i - 1 }
         instance_indices_list.each do |index|
           return_array << instances[index]
@@ -72,5 +68,14 @@ module Opsicle
       end
       return_array
     end
+
+    def check_for_valid_indices!(instance_indices_list, option_count)
+      valid_indices = 1..option_count
+
+      if instance_indices_list.all?{ |i| valid_indices.include?(i.to_i) }
+        raise StandardError, "At least one of the indices passed is invalid. Please try again."
+      end
+    end
+    private :check_for_valid_indices!
   end
 end

--- a/lib/opsicle/commands/delete_instance.rb
+++ b/lib/opsicle/commands/delete_instance.rb
@@ -72,7 +72,7 @@ module Opsicle
     def check_for_valid_indices!(instance_indices_list, option_count)
       valid_indices = 1..option_count
 
-      if instance_indices_list.all?{ |i| valid_indices.include?(i.to_i) }
+      unless instance_indices_list.all?{ |i| valid_indices.include?(i.to_i) }
         raise StandardError, "At least one of the indices passed is invalid. Please try again."
       end
     end

--- a/lib/opsicle/commands/delete_instance.rb
+++ b/lib/opsicle/commands/delete_instance.rb
@@ -6,6 +6,8 @@ require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"
 
+require "pry"
+
 module Opsicle
   class DeleteInstance
 
@@ -60,6 +62,11 @@ module Opsicle
         instances.each_with_index { |instance, index| puts "#{index.to_i + 1}) #{instance.status} - #{instance.hostname}" }
         instance_indices_string = @cli.ask("Which instances would you like to delete? (enter as a comma separated list)\n", String)
         instance_indices_list = instance_indices_string.split(/,\s*/)
+
+        if instance_indices_list.include?("0")
+          raise StandardError, "Any instances to delete must be indicated with numbers > 0."
+        end
+
         instance_indices_list.map! { |instance_index| instance_index.to_i - 1 }
         instance_indices_list.each do |index|
           return_array << instances[index]

--- a/lib/opsicle/commands/stop_instance.rb
+++ b/lib/opsicle/commands/stop_instance.rb
@@ -5,7 +5,7 @@ require "opsicle/ec2_adapter"
 require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"
-
+require"pry"
 module Opsicle
   class StopInstance
 
@@ -51,7 +51,7 @@ module Opsicle
     end
 
     def select_instances(layer)
-      instances = stoppable_instances(layer)
+      instances = stoppable_instances(layer) 
       return_array = []
       if instances.empty?
         puts "There are no stoppable instances."
@@ -72,7 +72,7 @@ module Opsicle
     def check_for_valid_indices!(instance_indices_list, option_count)
       valid_indices = 1..option_count
 
-      if instance_indices_list.all?{ |i| valid_indices.include?(i.to_i) }
+      unless instance_indices_list.all?{ |i| valid_indices.include?(i.to_i) }
         raise StandardError, "At least one of the indices passed is invalid. Please try again."
       end
     end

--- a/lib/opsicle/commands/stop_instance.rb
+++ b/lib/opsicle/commands/stop_instance.rb
@@ -5,7 +5,7 @@ require "opsicle/ec2_adapter"
 require "opsicle/manageable_layer"
 require "opsicle/manageable_instance"
 require "opsicle/manageable_stack"
-require"pry"
+
 module Opsicle
   class StopInstance
 
@@ -51,7 +51,7 @@ module Opsicle
     end
 
     def select_instances(layer)
-      instances = stoppable_instances(layer) 
+      instances = stoppable_instances(layer)
       return_array = []
       if instances.empty?
         puts "There are no stoppable instances."

--- a/lib/opsicle/commands/stop_instance.rb
+++ b/lib/opsicle/commands/stop_instance.rb
@@ -60,6 +60,11 @@ module Opsicle
         instances.each_with_index { |instance, index| puts "#{index.to_i + 1}) #{instance.status} - #{instance.hostname}" }
         instance_indices_string = @cli.ask("Which instances would you like to stop? (enter as a comma separated list)\n", String)
         instance_indices_list = instance_indices_string.split(/,\s*/)
+
+        if instance_indices_list.include?("0")
+          raise StandardError, "Any instances to stop must be indicated with numbers > 0."
+        end
+
         instance_indices_list.map! { |instance_index| instance_index.to_i - 1 }
         instance_indices_list.each do |index|
           return_array << instances[index]

--- a/lib/opsicle/commands/stop_instance.rb
+++ b/lib/opsicle/commands/stop_instance.rb
@@ -60,11 +60,7 @@ module Opsicle
         instances.each_with_index { |instance, index| puts "#{index.to_i + 1}) #{instance.status} - #{instance.hostname}" }
         instance_indices_string = @cli.ask("Which instances would you like to stop? (enter as a comma separated list)\n", String)
         instance_indices_list = instance_indices_string.split(/,\s*/)
-
-        if instance_indices_list.include?("0")
-          raise StandardError, "Any instances to stop must be indicated with numbers > 0."
-        end
-
+        check_for_valid_indices!(instance_indices_list, instances.count)
         instance_indices_list.map! { |instance_index| instance_index.to_i - 1 }
         instance_indices_list.each do |index|
           return_array << instances[index]
@@ -72,5 +68,14 @@ module Opsicle
       end
       return_array
     end
+
+    def check_for_valid_indices!(instance_indices_list, option_count)
+      valid_indices = 1..option_count
+
+      if instance_indices_list.all?{ |i| valid_indices.include?(i.to_i) }
+        raise StandardError, "At least one of the indices passed is invalid. Please try again."
+      end
+    end
+    private :check_for_valid_indices!
   end
 end

--- a/lib/opsicle/ec2_adapter.rb
+++ b/lib/opsicle/ec2_adapter.rb
@@ -1,8 +1,8 @@
 class Opsicle::Ec2Adapter
   attr_reader :client
 
-  def initialize(client)
-    @client = client.ec2
+  def initialize(opsicle_client)
+    @client = opsicle_client.ec2
   end
 
   def get_subnets

--- a/lib/opsicle/manageable_instance.rb
+++ b/lib/opsicle/manageable_instance.rb
@@ -75,7 +75,6 @@ module Opsicle
       new_hostname = auto_generated_hostname
       create_new_instance(new_hostname, instance_type, ami_id, agent_version, subnet_id)
       opsworks.start_instance(instance_id: new_instance_id)
-      add_tags
       puts "\nNew instance is starting…"
     end
 

--- a/lib/opsicle/questionnaire/eip_inquiry.rb
+++ b/lib/opsicle/questionnaire/eip_inquiry.rb
@@ -50,7 +50,7 @@ module Opsicle
       private :get_potential_target_instances
 
       def check_for_printable_items!(instances)
-        if instances.empty?
+        if instances.empty? # instances is the list of instances that an eip can be moved to
           raise StandardError, "You cannot move an EIP when there's only one instance running."
         end
       end

--- a/lib/opsicle/questionnaire/eip_inquiry.rb
+++ b/lib/opsicle/questionnaire/eip_inquiry.rb
@@ -18,6 +18,11 @@ module Opsicle
       def which_instance_should_get_eip(moveable_eip)
         puts "\nHere are all of the instances in the current instance's layer:"
         instances = get_potential_target_instances(moveable_eip)
+
+        if instances.empty?
+          raise StandardError, "You cannot move an EIP when there's only one instance running."
+        end
+
         print_potential_target_instances(instances)
         instance_index = ask_eip_question("What is your target instance?\n", instances)
         instances[instance_index].instance_id
@@ -40,7 +45,11 @@ module Opsicle
 
       def get_potential_target_instances(moveable_eip)
         instances = @opsworks_adapter.instances_by_layer(moveable_eip[:layer_id])
-        instances.select { |instance| instance.elastic_ip.nil? && instance.auto_scaling_type.nil? }
+        instances.select do |instance|
+          instance.elastic_ip.nil? &&
+          instance.auto_scaling_type.nil? &&
+          instance.status == "online"
+        end
       end
       private :get_potential_target_instances
     end

--- a/lib/opsicle/questionnaire/eip_inquiry.rb
+++ b/lib/opsicle/questionnaire/eip_inquiry.rb
@@ -18,11 +18,7 @@ module Opsicle
       def which_instance_should_get_eip(moveable_eip)
         puts "\nHere are all of the instances in the current instance's layer:"
         instances = get_potential_target_instances(moveable_eip)
-
-        if instances.empty?
-          raise StandardError, "You cannot move an EIP when there's only one instance running."
-        end
-
+        check_for_printable_items!(instances)
         print_potential_target_instances(instances)
         instance_index = ask_eip_question("What is your target instance?\n", instances)
         instances[instance_index].instance_id
@@ -52,6 +48,13 @@ module Opsicle
         end
       end
       private :get_potential_target_instances
+
+      def check_for_printable_items!(instances)
+        if instances.empty?
+          raise StandardError, "You cannot move an EIP when there's only one instance running."
+        end
+      end
+      private :check_for_printable_items!
     end
   end
 end

--- a/spec/opsicle/commands/delete_instance_spec.rb
+++ b/spec/opsicle/commands/delete_instance_spec.rb
@@ -27,9 +27,9 @@ describe Opsicle::DeleteInstance do
       describe_stacks: double(stack: [ opsworks_stack ]),
       describe_instances: double(instances: [ instance1 ])
     )
-  end 
+  end
 
-  let(:ec2_client) { double(:ec2_client) }  
+  let(:ec2_client) { double(:ec2_client) }
 
   let(:opsworks_adapter) do
     double(:opsworks_adapter,
@@ -92,10 +92,9 @@ describe Opsicle::DeleteInstance do
       end
 
       it "should not delete any instances" do
-        expect(opsworks_adapter).not_to receive(:delete_instance) 
+        expect(opsworks_adapter).not_to receive(:delete_instance)
         subject.execute
       end
     end
   end
 end
-

--- a/spec/opsicle/commands/delete_instance_spec.rb
+++ b/spec/opsicle/commands/delete_instance_spec.rb
@@ -3,79 +3,99 @@ require "opsicle"
 require 'gli'
 require "opsicle/user_profile"
 
-module Opsicle
-  describe DeleteInstance do
-    before do
-      @instance1 = double('instance1', :hostname => 'example-hostname-01', :status => 'active',
-                                       :ami_id => 'ami_id', :instance_type => 'instance_type',
-                                       :agent_version => 'agent_version', :stack_id => 1234567890,
-                                       :layer_ids => [12345, 67890], :auto_scaling_type => 'auto_scaling_type',
-                                       :os => 'os', :ssh_key_name => 'ssh_key_name',
-                                       :availability_zone => 'availability_zone', :virtualization_type => 'virtualization_type',
-                                       :subnet_id => 'subnet_id', :architecture => 'architecture',
-                                       :root_device_type => 'root_device_type', :install_updates_on_boot => 'install_updates_on_boot',
-                                       :ebs_optimized => 'ebs_optimized', :tenancy => 'tenancy', :instance_id => 'some-id')
-      @instance2 = double('instance2', :hostname => 'example-hostname-02', :status => 'active',
-                                       :ami_id => 'ami_id', :instance_type => 'instance_type',
-                                       :agent_version => 'agent_version', :stack_id => 1234567890,
-                                       :layer_ids => [12345, 67890], :auto_scaling_type => 'auto_scaling_type',
-                                       :os => 'os', :ssh_key_name => 'ssh_key_name',
-                                       :availability_zone => 'availability_zone', :virtualization_type => 'virtualization_type',
-                                       :subnet_id => 'subnet_id', :architecture => 'architecture',
-                                       :root_device_type => 'root_device_type', :install_updates_on_boot => 'install_updates_on_boot',
-                                       :ebs_optimized => 'ebs_optimized', :tenancy => 'tenancy', :instance_id => 'some-id')
-      @instances = double('instances', :instances => [@instance1, @instance2])
-      @layer1 = double('layer1', :name => 'layer-1', :layer_id => 12345, :instances => [@instance1, @instance2])
-      @layer2 = double('layer2', :name => 'layer-2', :layer_id => 67890, :instances => [@instance1, @instance2])
-      @layers = double('layers', :layers => [@layer1, @layer2])
-      @new_instance = double('new_instance', :instance_id => 1029384756)
-      @stack = double('stack', :vpc_id => "vpc-123456")
-      @stacks = double('stacks', :stacks => [@stack])
-      @opsworks = double('opsworks', :describe_instances => @instances, :describe_layers => @layers,
-                                     :create_instance => @new_instance, :describe_stacks => @stacks,
-                                     :start_instance => @new_instance)
-      @ec2 = double('ec2')
-      @config = double('config', :opsworks_config => {:stack_id => 1234567890})
-      @client = double('client', :config => @config, :opsworks => @opsworks, :ec2 => @ec2)
-      allow(@instances).to receive(:each_with_index)
-      @agent_version_1 = double('agent_version', :version => '3434-20160316181345')
-      @agent_version_2 = double('agent_version', :version => '3435-20160406115841')
-      @agent_version_3 = double('agent_version', :version => '3436-20160418214624')
-      @agent_versions = double('agent_versions', :agent_versions => [@agent_version_1, @agent_version_2, @agent_version_3])
-      allow(@opsworks).to receive(:describe_agent_versions).and_return(@agent_versions)
-      tag1 = double('tag', :value => 'Subnet', :key => 'Name')
-      @tags = [tag1]
-      @current_subnet = double('subnet', :tags => @tags, :availability_zone => 'us-east-1b')
-      allow(Aws::EC2::Subnet).to receive(:new).and_return(@current_subnet)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Layer?\n", Integer).and_return(2)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Instances? (enter as a comma separated list)\n", String).and_return('2')
-      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this hostname?\n1) Yes\n2) No", Integer).and_return(2)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Please write in the new instance's hostname and press ENTER:").and_return('example-hostname')
-      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this AMI ID? By overriding, you are choosing to override the current AMI ID for all of the following instances you're cloning.\n1) Yes\n2) No", Integer).and_return(2)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Which AMI ID?\n", Integer).and_return(1)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this agent version? By overriding, you are choosing to override the current agent version for all of the following instances you're cloning.\n1) Yes\n2) No", Integer).and_return(2)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Which agent version?\n", Integer).and_return(1)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this instance type?\n1) Yes\n2) No", Integer).and_return(2)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Please write in the new instance type press ENTER:").and_return('t2.micro')
-      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to override this subnet ID? By overriding, you are choosing to override the current subnet ID for all of the following instances you're cloning.\n1) Yes\n2) No", Integer).and_return(2)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Which subnet ID?\n", Integer).and_return(1)
-      allow_any_instance_of(HighLine).to receive(:ask).with("Do you wish to start this new instance?\n1) Yes\n2) No", Integer).and_return(1)
+describe Opsicle::DeleteInstance do
+  let(:config) { double(:config, opsworks_config: {stack_id: "1234"}) }
+  let(:opsicle_client) { double(:client, config: config, opsworks: opsworks_client, ec2: ec2_client) }
+  let(:opsworks_stack) { double(:stack, id: "1234", vpc_id: "21") }
+  let(:layer1) { double(:layer, name: "layer1", layer_id: "123") }
+  let(:layer2) { double(:layer, name: "layer2", layer_id: "456") }
+
+  let(:instance1) do
+    double(:instance,
+      name: "instance1",
+      layer_ids: [ "456" ],
+      status: "stopped",
+      auto_scaling_type: nil,
+      instance_id: "123",
+      hostname: "instance1"
+    )
+  end
+
+  let(:opsworks_client) do
+    double(:opsworks_client,
+      associate_elastic_ip: true,
+      describe_stacks: double(stack: [ opsworks_stack ]),
+      describe_instances: double(instances: [ instance1 ])
+    )
+  end 
+
+  let(:ec2_client) { double(:ec2_client) }  
+
+  let(:opsworks_adapter) do
+    double(:opsworks_adapter,
+      client: opsworks_client,
+      stack: opsworks_stack,
+      layers: [ layer1, layer2 ],
+      instances_by_stack: [ instance1 ]
+    )
+  end
+
+  let(:ec2_adapter) do
+    double(:ec2_adapter,
+      client: ec2_client,
+      stack: opsworks_stack,
+      elastic_ips: []
+    )
+  end
+
+  before do
+    allow(Opsicle::Client).to receive(:new).with("staging").and_return(opsicle_client)
+    allow(Opsicle::OpsworksAdapter).to receive(:new).and_return(opsworks_adapter)
+    allow_any_instance_of(HighLine).to receive(:ask).with("Layer?\n", Integer).and_return(2)
+  end
+
+  subject { described_class.new("staging") }
+
+
+  describe "#execute" do
+    context "when everything works as expected" do
+      before do
+        allow_any_instance_of(HighLine).to receive(:ask).with("Which instances would you like to delete? (enter as a comma separated list)\n", String).and_return("1")
+      end
+
+      it "should properly ask to delete instances" do
+        expect(opsworks_adapter).to receive(:delete_instance).with("123")
+        subject.execute
+      end
     end
 
-    subject{DeleteInstance.new("staging")}
+    context "when an improper value is passed in as something to delete" do
+      before do
+        allow_any_instance_of(HighLine).to receive(:ask).with("Which instances would you like to delete? (enter as a comma separated list)\n", String).and_return("-1")
+      end
 
-    # context "#execute" do
-    #   it "lists deleteable instances" do
-    #     allow(subject).to receive("staging"){[@instance1]}
-    #     expect(@stack).to receive(:deleteable_instances)
-    #     subject.execute
-    #   end
-    #
-    #   it "deletes the selected instance" do
-    #     allow(subject).to receive("staging"){[@instance1]}
-    #     expect(@opsworks).to receive(:delete_instance)
-    #     subject.execute
-    #   end
-    # end
+      it "should properly ask to delete instances" do
+        expect{subject.execute}.to raise_error(StandardError)
+      end
+    end
+
+    context "when there are no deletable instances" do
+      let(:instance1) do
+        double(:instance,
+          name: "instance1",
+          layer_ids: [ "456" ],
+          status: "online",
+          auto_scaling_type: nil,
+          instance_id: "123",
+          hostname: "instance1"
+        )
+      end
+
+      it "should not delete any instances" do
+        expect(opsworks_adapter).not_to receive(:delete_instance) 
+        subject.execute
+      end
+    end
   end
 end
+

--- a/spec/opsicle/commands/stop_instance_spec.rb
+++ b/spec/opsicle/commands/stop_instance_spec.rb
@@ -27,9 +27,9 @@ describe Opsicle::StopInstance do
       describe_stacks: double(stack: [ opsworks_stack ]),
       describe_instances: double(instances: [ instance1 ])
     )
-  end 
+  end
 
-  let(:ec2_client) { double(:ec2_client) }  
+  let(:ec2_client) { double(:ec2_client) }
 
   let(:opsworks_adapter) do
     double(:opsworks_adapter,
@@ -92,10 +92,9 @@ describe Opsicle::StopInstance do
       end
 
       it "should not stop any instances" do
-        expect(opsworks_adapter).not_to receive(:stop_instance) 
+        expect(opsworks_adapter).not_to receive(:stop_instance)
         subject.execute
       end
     end
   end
 end
-

--- a/spec/opsicle/commands/stop_instance_spec.rb
+++ b/spec/opsicle/commands/stop_instance_spec.rb
@@ -1,0 +1,101 @@
+require "spec_helper"
+require "opsicle"
+require 'gli'
+require "opsicle/user_profile"
+
+describe Opsicle::StopInstance do
+  let(:config) { double(:config, opsworks_config: {stack_id: "1234"}) }
+  let(:opsicle_client) { double(:client, config: config, opsworks: opsworks_client, ec2: ec2_client) }
+  let(:opsworks_stack) { double(:stack, id: "1234", vpc_id: "21") }
+  let(:layer1) { double(:layer, name: "layer1", layer_id: "123") }
+  let(:layer2) { double(:layer, name: "layer2", layer_id: "456") }
+
+  let(:instance1) do
+    double(:instance,
+      name: "instance1",
+      layer_ids: [ "456" ],
+      status: "online",
+      elastic_ip: nil,
+      instance_id: "123",
+      hostname: "instance1"
+    )
+  end
+
+  let(:opsworks_client) do
+    double(:opsworks_client,
+      associate_elastic_ip: true,
+      describe_stacks: double(stack: [ opsworks_stack ]),
+      describe_instances: double(instances: [ instance1 ])
+    )
+  end 
+
+  let(:ec2_client) { double(:ec2_client) }  
+
+  let(:opsworks_adapter) do
+    double(:opsworks_adapter,
+      client: opsworks_client,
+      stack: opsworks_stack,
+      layers: [ layer1, layer2 ],
+      instances_by_stack: [ instance1 ]
+    )
+  end
+
+  let(:ec2_adapter) do
+    double(:ec2_adapter,
+      client: ec2_client,
+      stack: opsworks_stack,
+      elastic_ips: []
+    )
+  end
+
+  before do
+    allow(Opsicle::Client).to receive(:new).with("staging").and_return(opsicle_client)
+    allow(Opsicle::OpsworksAdapter).to receive(:new).and_return(opsworks_adapter)
+    allow_any_instance_of(HighLine).to receive(:ask).with("Layer?\n", Integer).and_return(2)
+   end
+
+  subject { described_class.new("staging") }
+
+
+  describe "#execute" do
+    context "when everything works as expected" do
+      before do
+        allow_any_instance_of(HighLine).to receive(:ask).with("Which instances would you like to stop? (enter as a comma separated list)\n", String).and_return("1")
+      end
+
+      it "should properly ask to stop instances" do
+        expect(opsworks_adapter).to receive(:stop_instance).with("123")
+        subject.execute
+      end
+    end
+
+    context "when an improper value is passed in as something to stop" do
+      before do
+        allow_any_instance_of(HighLine).to receive(:ask).with("Which instances would you like to stop? (enter as a comma separated list)\n", String).and_return("-1")
+      end
+
+      it "should properly ask to stop instances" do
+        expect{subject.execute}.to raise_error(StandardError)
+      end
+    end
+
+    context "when there are no stoppable instances" do
+      let(:instance1) do
+        double(:instance,
+          name: "instance1",
+          layer_ids: [ "456" ],
+          status: "stopped",
+          elastic_ip: nil,
+          instance_id: "123",
+          hostname: "instance1"
+        )
+      end
+
+      it "should not stop any instances" do
+        expect(opsworks_adapter).not_to receive(:stop_instance) 
+        subject.execute
+      end
+    end
+  end
+end
+

--- a/spec/opsicle/questionnaire/eip_inquiry_spec.rb
+++ b/spec/opsicle/questionnaire/eip_inquiry_spec.rb
@@ -66,5 +66,55 @@ describe Opsicle::Questionnaire::EipInquiry do
     it "should return a single instance" do
       expect(instance_response).to eq("instance-id")
     end
+
+    context "when there are no target instances" do
+      let(:online_instance_with_eip) do
+        double(:instance,
+          elastic_ip: true,
+          auto_scaling_type: nil,
+          status: "stopped",
+          hostname: "example",
+          instance_id: "instance-id"
+        )
+      end
+
+      let(:online_instance_without_eip) do
+        double(:instance,
+          elastic_ip: nil,
+          auto_scaling_type: nil,
+          status: "stopped",
+          hostname: "example",
+          instance_id: "instance-id"
+        )
+      end
+
+      let(:stopped_instance) do
+        double(:instance,
+          elastic_ip: nil,
+          auto_scaling_type: nil,
+          status: "stopped",
+          hostname: "example",
+          instance_id: "instance-id"
+        )
+      end
+
+      it "should raise an error" do
+        expect{subject.which_instance_should_get_eip(eip_info)}.to raise_error(StandardError)
+      end
+    end
+  end
+
+  describe "#check_for_printable_items" do
+    context "when there are instances" do
+      it "should not raise an error" do
+        expect(subject.send(:check_for_printable_items!, [ 1, 2, 3 ])).to eq(nil)
+      end
+    end
+
+    context "when there are no instances" do
+      it "should raise an error" do
+        expect{subject.send(:check_for_printable_items!, [])}.to raise_error(StandardError)
+      end
+    end
   end
 end


### PR DESCRIPTION
What
----------------------
Address the following bugs:
* When asking users to select which instances to delete/stop, don't let them pass in 0; throw an error here.
* When a user is cloning an instance using a `-d` flag to use the defaults; at the end, don't ask them if they want to add tags to the instance.... let them move on with their day.
* When asking a user which instance they would like to move an EIP to, don't show instances that are "stopped", "booting", "requested", etc (aka we only want them to see "online" instances)
* If there's only one instance running (aka the one that currently has the EIP), then the code used to hang; don't do this, just indicate to the user that there's only one instance running.

Why
----------------------
Because it's good to occasionally fix the bugs in our code.

Deploy Plan
-----------
Release a patch version.

Merging this PR will close the following issues:
* https://github.com/sportngin/opsicle/issues/153
* https://github.com/sportngin/opsicle/issues/152
* https://github.com/sportngin/opsicle/issues/151
* https://github.com/sportngin/opsicle/issues/150

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run `bundle exec opsicle clone-instance -d [env]` and verify that at the end, it doesn't ask us if we wish to add tags
- [x] Run `bundle exec opsicle stop-instance [env]` and select 0 for the instance to stop... verify it throws an error
- [x] Run `bundle exec opsicle delete-instance [env]` and select 0 for the instance to delete... verify it throws an error
- [x] Run `bundle exec opsicle move-eip [env]` and verify that only online instances show up in the list
- [x] Run `bundle exec opsicle move-eip [env]` on a stack that only has one online instance and verify it throws an error instead of hanging