### PR TITLE
Do not add tasks when cloning with defaults

### DIFF
--- a/lib/opsicle/manageable_instance.rb
+++ b/lib/opsicle/manageable_instance.rb
@@ -75,7 +75,6 @@ module Opsicle
       new_hostname = auto_generated_hostname
       create_new_instance(new_hostname, instance_type, ami_id, agent_version, subnet_id)
       opsworks.start_instance(instance_id: new_instance_id)
-      add_tags
       puts "\nNew instance is starting…"
     end
 


### PR DESCRIPTION
What
----------------------
Removing add_tags method when using defaults to clone an instances.

Why
----------------------
Using defaults should be fast and unobtrusive

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
> Reference commonly used Regression test plans on the [QA Wiki](https://github.com/sportngin/qa-tests/wiki)
> Fill in scenarios below in checklist format.
> Consider Regression scenarios (did we break something else related to this change) in addition to Happy Path (testing the new feature directly).
> Evaluate the risk level and label accordingly and ensure the QA Plan matches the risk level!

- A step to reproduce (e.g.: navigate to http://example.com/foo/bar; fill a field labeled "login:" with  "boo"; click "submit"; press <kbd>Enter</kbd>)
- [ ] An assertion to verify (e.g. "that we are redirected to user dashboard"; "there's a message on the top of page saying 'login successful'"
