### PR TITLE
Fix bug in clone-instance when MFA is enforced

### DIFF
--- a/lib/opsicle/manageable_instance.rb
+++ b/lib/opsicle/manageable_instance.rb
@@ -169,7 +169,7 @@ module Opsicle
       if self.layer.subnet_id
         subnet_id = self.layer.subnet_id
       else
-        current_subnet = Aws::EC2::Subnet.new(id: self.subnet_id)
+        current_subnet = Aws::EC2::Subnet.new(id: self.subnet_id, client: @ec2)
         subnet_name = find_subnet_name(current_subnet)
         puts "\nCurrent subnet ID is \"#{subnet_name}\" #{current_subnet.availability_zone} (#{self.subnet_id})"
 


### PR DESCRIPTION
What
----------------------
Re-use existing EC2 API client that has AWS session token authenticated with MFA token.

https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Subnet.html#initialize-instance_method

Why
----------------------
If MFA is enforced through IAM policies, this direct subnet call will fail.

