### PR TITLE
IS-10856 do not copy install updates on boot

### DIFF
--- a/lib/opsicle/manageable_instance.rb
+++ b/lib/opsicle/manageable_instance.rb
@@ -20,7 +20,6 @@ module Opsicle
       :subnet_id,
       :architecture,
       :root_device_type,
-      :install_updates_on_boot,
       :ebs_optimized,
       :tenancy,
       :opsworks,
@@ -46,7 +45,6 @@ module Opsicle
       self.subnet_id = instance.subnet_id
       self.architecture = instance.architecture
       self.root_device_type = instance.root_device_type
-      self.install_updates_on_boot = instance.install_updates_on_boot
       self.ebs_optimized = instance.ebs_optimized
       self.tenancy = instance.tenancy
       self.opsworks = opsworks
@@ -240,7 +238,6 @@ module Opsicle
         virtualization_type: self.virtualization_type,
         architecture: self.architecture, # accepts x86_64, i386
         root_device_type: self.root_device_type, # accepts ebs, instance-store
-        install_updates_on_boot: self.install_updates_on_boot,
         #ebs_optimized: self.ebs_optimized,
         agent_version: agent_version,
         tenancy: self.tenancy,


### PR DESCRIPTION
What
----------------------
Removing `install_updates_on_boot` from list of attributes to clone from cloned instance.

Why
----------------------
`opsicle clone-instance` did not respect the value of `install_updates_on_boot` set at the OpsWorks Layer level.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----


QA Plan
-------
- [x] Pick an instance that has been running for a while (it should have the default, `true`, value in `install_updates_on_boot`) Use the command below to check it.
```
INSTANCE_ID=<OLD_instance_id>
aws ec2 describe-instance-attribute --instance-id $INSTANCE_ID --attribute userData --output text --query "UserData.Value" | base64 --decode | gunzip | grep install_updates_on_boot
```
- [x] Set InstallUpdatesOnBoot to false for the layer where the instance was cloned.
`aws opsworks update-layer --no-install-updates-on-boot --layer-id 3a8ced50-7655-42f9-90bc-f1530311c3d8`
- [x] Link to the .opsicle file from the app repo for the app you cloned. `ln -sf ~/sportsengine/sport_ngin_live/.opsicle`
- [x] Run `bundle exec ./bin/opsicle clone-instance staging -d`
- [x] Confirm the new instance has `install_updates_on_boot` set to false
```
INSTANCE_ID=<NEW_instance_id>
aws ec2 describe-instance-attribute --instance-id $INSTANCE_ID --attribute userData --output text --query "UserData.Value" | base64 --decode | gunzip | grep install_updates_on_boot
```
