### PR TITLE
Option to run a Docker container for Opsicle commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:jessie-slim
+FROM ruby:slim
 
 RUN apt-get update -q && \
     apt-get install -qy \
-    ruby-dev rubygems libncurses5-dev libncursesw5-dev gcc libffi-dev make ssh
+    libncurses5-dev libncursesw5-dev gcc libffi-dev make ssh
 
 RUN gem install opsicle
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:jessie-slim
+
+RUN apt-get update -q && \
+    apt-get install -qy \
+    ruby-dev rubygems libncurses5-dev libncursesw5-dev gcc libffi-dev make ssh
+
+RUN gem install opsicle
+
+ENTRYPOINT ["opsicle"]

--- a/README.markdown
+++ b/README.markdown
@@ -110,3 +110,22 @@ For example:
 opsicle --debug update staging stack -j '{"use_opsworks_security_groups":false, "custom_json":"{\"foo\":5}"}'
 opsicle --debug update staging app -y app.yml
 ```
+
+### Using a Docker Container
+Since local dev environments change so frequently, this is an option to run opsicle commands inside of an isolated Docker container. This 
+will help mitigate issues on your local environment as it should be the same environment in the docker container every time. There is minimal
+setup to get this method to work.
+
+Create the Docker image:
+```
+docker build .
+```
+
+Create an alias in your .bashrc file:
+```
+alias opsicle="docker run -it -v $(pwd)/.opsicle:/.opsicle -v ~/.aws/credentials:/root/.aws/credentials -v ~/.ssh/id_rsa:/root/.ssh/id_rsa <HASH_FROM_DOCKER_BUILD>'
+source ~/.bashrc
+```
+
+This will mount the .opsicle config file for the directory you are currently in. It will also mount your AWS credentials file and your SSH private key when starting the container. 
+You can then run opsicle commands as if you were using the executable, but it will be running in a clean, isolated container.

--- a/README.markdown
+++ b/README.markdown
@@ -112,7 +112,7 @@ opsicle --debug update staging app -y app.yml
 ```
 
 ### Using a Docker Container
-Since local dev environments change so frequently, this is an option to run opsicle commands inside of an isolated Docker container. This 
+Since local dev environments change so frequently, this is an option to run opsicle commands inside of an isolated Docker container. This
 will help mitigate issues on your local environment as it should be the same environment in the docker container every time. There is minimal
 setup to get this method to work.
 
@@ -123,9 +123,8 @@ docker build . -t dev/opsicle:latest
 
 Create an alias in your .bashrc file:
 ```
-alias opsicle="docker run -it -v $(pwd)/.opsicle:/.opsicle -v ~/.aws/credentials:/root/.aws/credentials -v ~/.ssh/id_rsa:/root/.ssh/id_rsa dev/opsicle:latest'
-source ~/.bashrc
+alias opsicle='docker run -it -v $(pwd)/.opsicle:/.opsicle -v ~/.aws/credentials:/root/.aws/credentials -v ~/.ssh:/root/.ssh dev/opsicle:latest'
 ```
 
-This will mount the .opsicle config file for the directory you are currently in. It will also mount your AWS credentials file and your SSH private key when starting the container. 
+This will mount the .opsicle config file for the directory you are currently in. It will also mount your AWS credentials file and your SSH private key when starting the container.
 You can then run opsicle commands as if you were using the executable, but it will be running in a clean, isolated container.

--- a/README.markdown
+++ b/README.markdown
@@ -118,12 +118,12 @@ setup to get this method to work.
 
 Create the Docker image:
 ```
-docker build .
+docker build . -t dev/opsicle:latest
 ```
 
 Create an alias in your .bashrc file:
 ```
-alias opsicle="docker run -it -v $(pwd)/.opsicle:/.opsicle -v ~/.aws/credentials:/root/.aws/credentials -v ~/.ssh/id_rsa:/root/.ssh/id_rsa <HASH_FROM_DOCKER_BUILD>'
+alias opsicle="docker run -it -v $(pwd)/.opsicle:/.opsicle -v ~/.aws/credentials:/root/.aws/credentials -v ~/.ssh/id_rsa:/root/.ssh/id_rsa dev/opsicle:latest'
 source ~/.bashrc
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -126,5 +126,5 @@ Create an alias in your .bashrc file:
 alias opsicle='docker run -it -v $(pwd)/.opsicle:/.opsicle -v ~/.aws/credentials:/root/.aws/credentials -v ~/.ssh:/root/.ssh dev/opsicle:latest'
 ```
 
-This will mount the .opsicle config file for the directory you are currently in. It will also mount your AWS credentials file and your SSH private key when starting the container.
+This will mount the .opsicle config file for the directory you are currently in. It will also mount your AWS credentials file and your .ssh directory when starting the container.
 You can then run opsicle commands as if you were using the executable, but it will be running in a clean, isolated container.


### PR DESCRIPTION
What
----------------------
Adding the option to run opsicle commands in a controlled environment.

Why
----------------------
Local developer environments change frequently and this is a way to maintain it runs the same every time without having to do wrestle with your local.

Deploy Plan
-----------
n/a

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
n/a

QA Plan
-------
- [x] `docker build . -t dev/opsicle:latest` ~10 min
- [x] Follow the README to add the opsicle alias
- [x] `opsicle ssh staging` (in applicable repo)
